### PR TITLE
MDStore Tests for Utilities

### DIFF
--- a/coda/coda_mdstore/tests/__init__.py
+++ b/coda/coda_mdstore/tests/__init__.py
@@ -1,0 +1,1 @@
+CODA_XML = '{http://digital2.library.unt.edu/coda/bagxml/}codaXML'

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -487,6 +487,9 @@ def bag_xml():
 @pytest.mark.django_db
 @pytest.mark.usefixture('bag_xml')
 class TestCreateBag:
+    """
+    Tests for coda_mdstore.presentation.createBag.
+    """
 
     @pytest.mark.xfail(reason='Exception in function will never be raised.')
     def test_raises_exception_when_xml_cannot_be_parsed(self):
@@ -515,6 +518,9 @@ class TestCreateBag:
 @pytest.mark.django_db
 @pytest.mark.usefixture('bag_xml')
 class TestUpdateBag:
+    """
+    Tests for coda_mdstore.presentation.updateBag.
+    """
     CODA_XML = '{http://digital2.library.unt.edu/coda/bagxml/}codaXML'
 
     def test_returns_bag(self, bag_xml, rf):

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -153,3 +153,57 @@ class TestGetNodeByName:
         node = presentation.getNodeByName(person_xml, name)
         assert node.tag == name
         assert node.text == value
+
+
+class TestNodeEntry:
+    """
+    Tests for coda_mdstore.presentation.nodeEntry.
+    """
+
+    def test_xml_has_node_attributes(self):
+        node = factories.NodeFactory.build()
+        tree = presentation.nodeEntry(node)
+        xml_str = etree.tostring(tree)
+
+        xml_obj = objectify.fromstring(xml_str)
+        assert xml_obj.content.node.name == node.node_name
+        assert xml_obj.content.node.capacity == node.node_capacity
+        assert xml_obj.content.node.size == node.node_size
+        assert xml_obj.content.node.path == node.node_path
+        assert xml_obj.content.node.url == node.node_url
+        assert xml_obj.content.node.last_checked == str(node.last_checked)
+        assert xml_obj.content.node.countchildren() == 6
+
+    def test_xml_id(self):
+        node = factories.NodeFactory.build()
+        web_root = 'example.com'
+
+        tree = presentation.nodeEntry(node, web_root)
+        xml_str = etree.tostring(tree)
+        xml_obj = objectify.fromstring(xml_str)
+
+        assert web_root in xml_obj.id.text
+
+    def test_xml_title(self):
+        node = factories.NodeFactory.build()
+        tree = presentation.nodeEntry(node)
+        xml_str = etree.tostring(tree)
+
+        xml_obj = objectify.fromstring(xml_str)
+        assert xml_obj.title == node.node_name
+
+    def test_xml_has_author_name_element(self):
+        node = factories.NodeFactory.build()
+        tree = presentation.nodeEntry(node)
+        xml_str = etree.tostring(tree)
+
+        xml_obj = objectify.fromstring(xml_str)
+        assert hasattr(xml_obj.author, 'name')
+
+    def test_xml_has_author_uri_element(self):
+        node = factories.NodeFactory.build()
+        tree = presentation.nodeEntry(node)
+        xml_str = etree.tostring(tree)
+
+        xml_obj = objectify.fromstring(xml_str)
+        assert hasattr(xml_obj.author, 'uri')

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -69,8 +69,7 @@ class TestMakeBagAtomFeed:
         assert feed.link.get('href') == _id
         assert feed.link.get('rel') == 'self'
 
-    @mock.patch('coda_mdstore.presentation.wrapAtom')
-    def test_without_bag_objects(self, wrapAtom):
+    def test_without_bag_objects(self):
         title = 'test title'
         _id = 'test-id'
         bag_list = []
@@ -78,9 +77,9 @@ class TestMakeBagAtomFeed:
         result = presentation.makeBagAtomFeed(bag_list, _id, title)
         feed = objectify.fromstring(etree.tostring(result))
 
-        assert wrapAtom.call_count == 0
         assert feed.id == _id
         assert feed.title == title
         assert feed.updated.text is None
         assert feed.link.get('href') == _id
         assert feed.link.get('rel') == 'self'
+        assert feed.countchildren() == 4

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -404,6 +404,8 @@ class TestXmlToBagObject:
     def test_has_bag_info_objects(self, bag_xml):
         bag, bag_infos, error = presentation.xmlToBagObject(bag_xml)
         assert len(bag_infos) == 2
+        # Verify that all of the bag_infos are instances of models.Bag_Info
+        assert all([isinstance(m, models.Bag_Info) for m in bag_infos])
 
     def test_has_no_bag_info_objects(self, bag_xml):
         del bag_xml.bagInfo.item

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -141,7 +141,7 @@ class TestObjectsToXML:
         assert bag_xml.name == bag.name
         assert bag_xml.fileCount == bag.files
         assert bag_xml.payloadSize == bag.size
-        assert bag_xml.payloadSize == bag.size
+        assert str(bag_xml.bagitVersion) == bag.bagit_version
 
     def test_bag_info_attribute_conversion(self):
         bag = factories.FullBagFactory.create()

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -48,6 +48,9 @@ class TestPercent:
 
 
 class TestBagFullTextSearch:
+    """
+    Tests for coda_mdstore.views.bagFullTextSearch.
+    """
 
     @pytest.mark.xfail(reason='FULLTEXT index is required.')
     def test_returns_paginator_object(self):

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -83,3 +83,31 @@ class TestMakeBagAtomFeed:
         assert feed.link.get('href') == _id
         assert feed.link.get('rel') == 'self'
         assert feed.countchildren() == 4
+
+
+@pytest.mark.django_db
+class TestObjectsToXML:
+    """
+    Test for coda_mdstore.presentation.objectsToXML.
+    """
+
+    def test_bag_attribute_conversion(self):
+        bag = factories.FullBagFactory.create()
+        xml = etree.tostring(presentation.objectsToXML(bag))
+        bag_xml = objectify.fromstring(xml)
+
+        assert bag_xml.name == bag.name
+        assert bag_xml.fileCount == bag.files
+        assert bag_xml.payloadSize == bag.size
+        assert bag_xml.payloadSize == bag.size
+
+    def test_bag_info_attribute_conversion(self):
+        bag = factories.FullBagFactory.create()
+        xml = etree.tostring(presentation.objectsToXML(bag))
+        bag_xml = objectify.fromstring(xml)
+
+        for i, bag_info in enumerate(bag.bag_info_set.all()):
+            bag_info_xml = bag_xml.bagInfo.item[i]
+            assert bag_info_xml.name.text == bag_info.field_name
+            assert bag_info_xml.body.text == bag_info.field_body
+            assert bag_info_xml.countchildren() == 2

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -130,7 +130,7 @@ class TestMakeBagAtomFeed:
 @pytest.mark.django_db
 class TestObjectsToXML:
     """
-    Test for coda_mdstore.presentation.objectsToXML.
+    Tests for coda_mdstore.presentation.objectsToXML.
     """
 
     def test_bag_attribute_conversion(self):

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -202,12 +202,18 @@ class TestNodeEntry:
     Tests for coda_mdstore.presentation.nodeEntry.
     """
 
+    def convert_etree(self, tree):
+        """
+        Test case helper method to convert etree XML to objectify XML.
+        """
+        return objectify.fromstring(etree.tostring(tree))
+
     def test_xml_has_node_attributes(self):
         node = factories.NodeFactory.build()
         tree = presentation.nodeEntry(node)
-        xml_str = etree.tostring(tree)
 
-        xml_obj = objectify.fromstring(xml_str)
+        xml_obj = self.convert_etree(tree)
+
         assert xml_obj.content.node.name == node.node_name
         assert xml_obj.content.node.capacity == node.node_capacity
         assert xml_obj.content.node.size == node.node_size
@@ -221,33 +227,26 @@ class TestNodeEntry:
         web_root = 'example.com'
 
         tree = presentation.nodeEntry(node, web_root)
-        xml_str = etree.tostring(tree)
-        xml_obj = objectify.fromstring(xml_str)
+        xml_obj = self.convert_etree(tree)
 
         assert web_root in xml_obj.id.text
 
     def test_xml_title(self):
         node = factories.NodeFactory.build()
         tree = presentation.nodeEntry(node)
-        xml_str = etree.tostring(tree)
-
-        xml_obj = objectify.fromstring(xml_str)
+        xml_obj = self.convert_etree(tree)
         assert xml_obj.title == node.node_name
 
     def test_xml_has_author_name_element(self):
         node = factories.NodeFactory.build()
         tree = presentation.nodeEntry(node)
-        xml_str = etree.tostring(tree)
-
-        xml_obj = objectify.fromstring(xml_str)
+        xml_obj = self.convert_etree(tree)
         assert hasattr(xml_obj.author, 'name')
 
     def test_xml_has_author_uri_element(self):
         node = factories.NodeFactory.build()
         tree = presentation.nodeEntry(node)
-        xml_str = etree.tostring(tree)
-
-        xml_obj = objectify.fromstring(xml_str)
+        xml_obj = self.convert_etree(tree)
         assert hasattr(xml_obj.author, 'uri')
 
 

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -280,4 +280,7 @@ class TestCreateNode:
         assert node.node_size == created_node.node_size
         assert node.node_path == created_node.node_path
         assert node.node_url == created_node.node_url
+
+        # Verify that the attribute exists, but do not attempt to guess
+        # the value.
         assert hasattr(node, 'last_checked')

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -340,6 +340,7 @@ class TestXmlToBagObject:
             <bag:bagitVersion>0.96</bag:bagitVersion>
             <bag:lastStatus>fail</bag:lastStatus>
             <bag:lastVerified>2015-01-01</bag:lastVerified>
+            <bag:baggingDate>2015-01-01</bag:baggingDate>
             <bag:bagInfo>
                 <bag:item>
                     <bag:name>Bagging-Date</bag:name>
@@ -436,6 +437,13 @@ class TestXmlToBagObject:
         assert error is None
 
     def test_baggingDate_not_set(self, bag_xml):
+        del bag_xml.baggingDate
+        bag, bag_infos, error = presentation.xmlToBagObject(bag_xml)
+
+        assert isinstance(bag.bagging_date, datetime)
+        assert error is None
+
+    def test_baggingDate_is_set(self, bag_xml):
         bag, bag_infos, error = presentation.xmlToBagObject(bag_xml)
 
         assert isinstance(bag.bagging_date, datetime)

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -222,7 +222,7 @@ class TestUpdateNode:
     def test_node_not_found(self, rf):
         node = factories.NodeFactory.build()
         node_tree = presentation.nodeEntry(node)
-        node_xml = etree.tostring(node_tree, pretty_print=True)
+        node_xml = etree.tostring(node_tree)
 
         request = rf.post('/', node_xml, 'application/xml')
         response = presentation.updateNode(request)
@@ -232,7 +232,7 @@ class TestUpdateNode:
     def test_node_found_and_path_does_not_include_node_name(self, rf):
         node = factories.NodeFactory.build()
         node_tree = presentation.nodeEntry(node)
-        node_xml = etree.tostring(node_tree, pretty_print=True)
+        node_xml = etree.tostring(node_tree)
 
         node.save()
 
@@ -248,7 +248,7 @@ class TestUpdateNode:
 
         node.node_size = '0'
         node_tree = presentation.nodeEntry(node)
-        node_xml = etree.tostring(node_tree, pretty_print=True)
+        node_xml = etree.tostring(node_tree)
 
         url = '/node/{0}/detail'.format(node.node_name)
         request = rf.post(url, node_xml, 'application/xml')
@@ -264,7 +264,7 @@ class TestCreateNode:
     def test_returns_node_object(self, rf):
         node = factories.NodeFactory.build()
         node_tree = presentation.nodeEntry(node)
-        node_xml = etree.tostring(node_tree, pretty_print=True)
+        node_xml = etree.tostring(node_tree)
 
         request = rf.post('/', node_xml, 'application/xml')
         created_node = presentation.createNode(request)
@@ -273,7 +273,7 @@ class TestCreateNode:
     def test_created_node_attributes(self, rf):
         node = factories.NodeFactory.build()
         node_tree = presentation.nodeEntry(node)
-        node_xml = etree.tostring(node_tree, pretty_print=True)
+        node_xml = etree.tostring(node_tree)
 
         request = rf.post('/', node_xml, 'application/xml')
         created_node = presentation.createNode(request)

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from django.core.paginator import Paginator
+from django.core.paginator import Paginator, Page
 from django.http import HttpResponse
 from lxml import etree, objectify
 import mock
@@ -10,6 +10,41 @@ from .. import factories
 from .. import models
 from .. import presentation
 from .. import views
+
+
+class TestPaginateEntries:
+    """
+    Tests for coda_mdstore.views.paginate_entries.
+    """
+
+    def test_returns_paginator_object(self, rf):
+        request = rf.get('/')
+        page = views.paginate_entries(request, [])
+        assert isinstance(page, Page)
+
+    def test_page_number_defaults_to_one(self, rf):
+        request = rf.get('/', {'page': 'foo'})
+        page = views.paginate_entries(request, [])
+        assert page.number == 1
+
+    def test_invalid_page_defaults_to_last_page(self, rf):
+        request = rf.get('/', {'page': 5})
+        page = views.paginate_entries(request, [1, 2, 3], 1)
+        assert page.number == 3
+
+
+class TestPercent:
+    """
+    Tests for coda_mdstore.views.percent.
+    """
+
+    def test_returns_float(self):
+        result = views.percent(1, 2)
+        assert isinstance(result, float)
+
+    def test_return_value(self):
+        result = views.percent(1, 2)
+        assert result == 50.0
 
 
 class TestBagFullTextSearch:

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -1,6 +1,7 @@
 from django.core.paginator import Paginator
 import pytest
 
+from .. import presentation
 from .. import views
 from .. import factories
 
@@ -12,3 +13,32 @@ class TestBagFullTextSearch:
         factories.FullBagFactory.create_batch(15)
         paginator = views.bagFullTextSearch('test search')
         assert isinstance(paginator, Paginator)
+
+
+@pytest.mark.django_db
+@pytest.mark.xfail(reason='FULLTEXT index is required.')
+class TestBagSearch:
+    """
+    Tests for coda_mdstore.presentation.bagSearch.
+    """
+
+    def test_searches_bag_info_objects(self):
+        factories.FullBagFactory.create_batch(10)
+        bag_list = presentation.bagSearch('3.14')
+        assert len(bag_list) == 10
+
+    def test_search_bags_only(self):
+        # The BagFactory will not create any assocated Bag_Info objects.
+        factories.BagFactory.create_batch(10)
+        bag_list = presentation.bagSearch('id')
+        assert len(bag_list) == 10
+
+    def test_search_returns_no_bags(self):
+        bag_list = presentation.bagSearch('')
+        assert len(bag_list) == 0
+
+    def test_search_finds_bag_by_name():
+        assert 0
+
+    def test_search_finds_bag_by_bag_info():
+        assert 0

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -111,3 +111,45 @@ class TestObjectsToXML:
             assert bag_info_xml.name.text == bag_info.field_name
             assert bag_info_xml.body.text == bag_info.field_body
             assert bag_info_xml.countchildren() == 2
+
+
+@pytest.fixture
+def person_xml():
+    return etree.fromstring(
+        """
+        <person>
+            <name>John Doe</name>
+            <age>34</age>
+        </person>
+        """
+    )
+
+
+@pytest.mark.usefixture('person_xml')
+class TestGetValueByName:
+    """
+    Tests for coda_mdstore.presentation.getValueByName.
+    """
+
+    @pytest.mark.parametrize('name, value', [
+        ('name', 'John Doe'),
+        ('age', '34')
+    ])
+    def test_returns_value(self, name, value, person_xml):
+        assert presentation.getValueByName(person_xml, name) == value
+
+
+@pytest.mark.usefixture('person_xml')
+class TestGetNodeByName:
+    """
+    Tests for coda_mdstore.presentation.getNodeByName.
+    """
+
+    @pytest.mark.parametrize('name, value', [
+        ('name', 'John Doe'),
+        ('age', '34')
+    ])
+    def test_returns_node(self, name, value, person_xml):
+        node = presentation.getNodeByName(person_xml, name)
+        assert node.tag == name
+        assert node.text == value

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -98,31 +98,31 @@ class TestMakeBagAtomFeed:
     @mock.patch('coda_mdstore.presentation.wrapAtom', lambda *args: etree.Element('atomEntry'))
     def test_with_bag_objects(self, *args):
         title = 'test title'
-        _id = 'test-id'
+        feed_id = 'test-id'
         bag_list = factories.FullBagFactory.create_batch(5)
 
-        result = presentation.makeBagAtomFeed(bag_list, _id, title)
+        result = presentation.makeBagAtomFeed(bag_list, feed_id, title)
         feed = objectify.fromstring(etree.tostring(result))
 
         assert len(feed.atomEntry) == 5
-        assert feed.id == _id
+        assert feed.id == feed_id
         assert feed.title == title
         assert feed.updated.text is None
-        assert feed.link.get('href') == _id
+        assert feed.link.get('href') == feed_id
         assert feed.link.get('rel') == 'self'
 
     def test_without_bag_objects(self):
         title = 'test title'
-        _id = 'test-id'
+        feed_id = 'test-id'
         bag_list = []
 
-        result = presentation.makeBagAtomFeed(bag_list, _id, title)
+        result = presentation.makeBagAtomFeed(bag_list, feed_id, title)
         feed = objectify.fromstring(etree.tostring(result))
 
-        assert feed.id == _id
+        assert feed.id == feed_id
         assert feed.title == title
         assert feed.updated.text is None
-        assert feed.link.get('href') == _id
+        assert feed.link.get('href') == feed_id
         assert feed.link.get('rel') == 'self'
         assert feed.countchildren() == 4
 

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -514,7 +514,7 @@ class TestCreateBag:
     def test_raises_exception_when_content_element_not_present(self):
         with pytest.raises(Exception) as e:
             presentation.createBag('<root/>')
-        assert str(e) == 'No content to parse uploaded XML'
+        assert str(e) == 'No content element located'
 
     @mock.patch('coda_mdstore.presentation.xmlToBagObject')
     def test_raises_exception_when_xmlToBagObject_reports_error(self, mock, bag_xml):

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -12,6 +12,13 @@ from .. import presentation
 from .. import views
 
 
+def convert_etree(tree):
+    """
+    Convert etree object to an objectify object.
+    """
+    return objectify.fromstring(etree.tostring(tree))
+
+
 class TestPaginateEntries:
     """
     Tests for coda_mdstore.views.paginate_entries.
@@ -102,7 +109,7 @@ class TestMakeBagAtomFeed:
         bag_list = factories.FullBagFactory.create_batch(5)
 
         result = presentation.makeBagAtomFeed(bag_list, feed_id, title)
-        feed = objectify.fromstring(etree.tostring(result))
+        feed = convert_etree(result)
 
         assert len(feed.atomEntry) == 5
         assert feed.id == feed_id
@@ -117,7 +124,7 @@ class TestMakeBagAtomFeed:
         bag_list = []
 
         result = presentation.makeBagAtomFeed(bag_list, feed_id, title)
-        feed = objectify.fromstring(etree.tostring(result))
+        feed = convert_etree(result)
 
         assert feed.id == feed_id
         assert feed.title == title
@@ -135,8 +142,8 @@ class TestObjectsToXML:
 
     def test_bag_attribute_conversion(self):
         bag = factories.FullBagFactory.create()
-        xml = etree.tostring(presentation.objectsToXML(bag))
-        bag_xml = objectify.fromstring(xml)
+        tree = presentation.objectsToXML(bag)
+        bag_xml = convert_etree(tree)
 
         assert bag_xml.name == bag.name
         assert bag_xml.fileCount == bag.files
@@ -145,8 +152,8 @@ class TestObjectsToXML:
 
     def test_bag_info_attribute_conversion(self):
         bag = factories.FullBagFactory.create()
-        xml = etree.tostring(presentation.objectsToXML(bag))
-        bag_xml = objectify.fromstring(xml)
+        tree = presentation.objectsToXML(bag)
+        bag_xml = convert_etree(tree)
 
         for i, bag_info in enumerate(bag.bag_info_set.all()):
             bag_info_xml = bag_xml.bagInfo.item[i]
@@ -202,17 +209,11 @@ class TestNodeEntry:
     Tests for coda_mdstore.presentation.nodeEntry.
     """
 
-    def convert_etree(self, tree):
-        """
-        Test case helper method to convert etree XML to objectify XML.
-        """
-        return objectify.fromstring(etree.tostring(tree))
-
     def test_xml_has_node_attributes(self):
         node = factories.NodeFactory.build()
         tree = presentation.nodeEntry(node)
 
-        xml_obj = self.convert_etree(tree)
+        xml_obj = convert_etree(tree)
 
         assert xml_obj.content.node.name == node.node_name
         assert xml_obj.content.node.capacity == node.node_capacity
@@ -227,26 +228,26 @@ class TestNodeEntry:
         web_root = 'example.com'
 
         tree = presentation.nodeEntry(node, web_root)
-        xml_obj = self.convert_etree(tree)
+        xml_obj = convert_etree(tree)
 
         assert web_root in xml_obj.id.text
 
     def test_xml_title(self):
         node = factories.NodeFactory.build()
         tree = presentation.nodeEntry(node)
-        xml_obj = self.convert_etree(tree)
+        xml_obj = convert_etree(tree)
         assert xml_obj.title == node.node_name
 
     def test_xml_has_author_name_element(self):
         node = factories.NodeFactory.build()
         tree = presentation.nodeEntry(node)
-        xml_obj = self.convert_etree(tree)
+        xml_obj = convert_etree(tree)
         assert hasattr(xml_obj.author, 'name')
 
     def test_xml_has_author_uri_element(self):
         node = factories.NodeFactory.build()
         tree = presentation.nodeEntry(node)
-        xml_obj = self.convert_etree(tree)
+        xml_obj = convert_etree(tree)
         assert hasattr(xml_obj.author, 'uri')
 
 

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -3,9 +3,10 @@ from lxml import etree, objectify
 import mock
 import pytest
 
+from .. import factories
+from .. import models
 from .. import presentation
 from .. import views
-from .. import factories
 
 
 class TestBagFullTextSearch:
@@ -211,6 +212,9 @@ class TestNodeEntry:
 
 @pytest.mark.django_db
 class TestUpdateNode:
+    """
+    Tests for coda_mdstore.presentation.updateNode.
+    """
 
     def test_node_not_found(self, rf):
         node = factories.NodeFactory.build()
@@ -247,3 +251,33 @@ class TestUpdateNode:
         request = rf.post(url, node_xml, 'application/xml')
         updated_node = presentation.updateNode(request)
         assert updated_node.node_size == 0
+
+
+class TestCreateNode:
+    """
+    Tests for coda_mdstore.presentation.createNode.
+    """
+
+    def test_returns_node_object(self, rf):
+        node = factories.NodeFactory.build()
+        node_tree = presentation.nodeEntry(node)
+        node_xml = etree.tostring(node_tree, pretty_print=True)
+
+        request = rf.post('/', node_xml, 'application/xml')
+        created_node = presentation.createNode(request)
+        assert isinstance(created_node, models.Node)
+
+    def test_created_node_attributes(self, rf):
+        node = factories.NodeFactory.build()
+        node_tree = presentation.nodeEntry(node)
+        node_xml = etree.tostring(node_tree, pretty_print=True)
+
+        request = rf.post('/', node_xml, 'application/xml')
+        created_node = presentation.createNode(request)
+
+        assert node.node_name == created_node.node_name
+        assert node.node_capacity == created_node.node_capacity
+        assert node.node_size == created_node.node_size
+        assert node.node_path == created_node.node_path
+        assert node.node_url == created_node.node_url
+        assert hasattr(node, 'last_checked')

--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -12,6 +12,7 @@ from django import http
 from .. import views
 from .. import models
 from ..factories import FullBagFactory, NodeFactory, ExternalIdentifierFactory
+from . import CODA_XML
 
 
 # Add this mark so that we are not loading all the URLs for
@@ -369,7 +370,6 @@ class TestExternalIdentiferSearch:
     """
     Tests for coda_mdstore.views.externalIdentifierSearch.
     """
-    CODA_XML = '{http://digital2.library.unt.edu/coda/bagxml/}codaXML'
 
     def test_no_identifier_renders_html(self, rf):
         request = rf.get('/')
@@ -394,7 +394,7 @@ class TestExternalIdentiferSearch:
         response = views.externalIdentifierSearch(request, bag.name)
 
         bagxml = objectify.fromstring(response.content)
-        bag_entry = bagxml.entry.content[self.CODA_XML]
+        bag_entry = bagxml.entry.content[CODA_XML]
 
         assert str(bag_entry.bagitVersion) == bag.bagit_version
         assert bag_entry.payloadSize == bag.size
@@ -426,7 +426,7 @@ class TestExternalIdentiferSearch:
         response = views.externalIdentifierSearch(request, ext_id.value)
 
         bagxml = objectify.fromstring(response.content)
-        bag_entry = bagxml.entry.content[self.CODA_XML]
+        bag_entry = bagxml.entry.content[CODA_XML]
 
         assert str(bag_entry.bagitVersion) == bag.bagit_version
         assert bag_entry.payloadSize == bag.size
@@ -459,8 +459,8 @@ class TestExternalIdentiferSearch:
 
         bagxml1 = objectify.fromstring(response1.content)
         bagxml2 = objectify.fromstring(response2.content)
-        bag_entry1 = bagxml1.entry.content[self.CODA_XML]
-        bag_entry2 = bagxml2.entry.content[self.CODA_XML]
+        bag_entry1 = bagxml1.entry.content[CODA_XML]
+        bag_entry2 = bagxml2.entry.content[CODA_XML]
 
         assert bag_entry1.name == bag_entry2.name
         assert bag_entry1.fileCount == bag_entry2.fileCount
@@ -494,8 +494,8 @@ class TestExternalIdentiferSearch:
 
         bagxml1 = objectify.fromstring(response1.content)
         bagxml2 = objectify.fromstring(response2.content)
-        bag_entry1 = bagxml1.entry.content[self.CODA_XML]
-        bag_entry2 = bagxml2.entry.content[self.CODA_XML]
+        bag_entry1 = bagxml1.entry.content[CODA_XML]
+        bag_entry2 = bagxml2.entry.content[CODA_XML]
 
         assert bag_entry1.name == bag_entry2.name
         assert bag_entry1.fileCount == bag_entry2.fileCount
@@ -678,7 +678,7 @@ class TestBagFullTextSearchHTMLView:
         context = response.context[-1]
 
         assert context['searchString'] == ''
-        assert context['entries'] == None
+        assert context['entries'] is None
         assert 'query' in context
 
     def test_renders_correct_template(self, client):
@@ -824,7 +824,6 @@ class TestAppBag:
     """
     Tests for coda_mdstore.views.app_bag.
     """
-    CODA_XML = '{http://digital2.library.unt.edu/coda/bagxml/}codaXML'
 
     def test_get_request_returns_not_found(self, rf):
         request = rf.get('/', HTTP_HOST='example.com')
@@ -863,7 +862,7 @@ class TestAppBag:
         assert response['Content-Type'] == 'application/atom+xml'
 
         tree = objectify.fromstring(response.content)
-        bag_xml = tree.content[self.CODA_XML]
+        bag_xml = tree.content[CODA_XML]
         assert bag_xml.name == bag.name
 
     @pytest.mark.xfail(reason='WSGI request objects do not have a ._req '

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 99


### PR DESCRIPTION
This provides tests for the following functions:

- `coda_mdstore.views.paginage_entries`
- `coda_mdstore.views.percent`
- `coda_mdstore.views.bagFullTextSearch`
- `coda_mdstore.presentation.bagSearch`
- `coda_mdstore.presentation.makeBagAtomFeed`
- `coda_mdstore.presentation.objectsToXML`
- `coda_mdstore.presentation.getValueByName`
- `coda_mdstore.presentation.getNodeByName`
- `coda_mdstore.presentation.nodeEntry`
- `coda_mdstore.presentation.updateNode`
- `coda_mdstore.presentation.createNode`
- `coda_mdstore.presentation.xmlToBagObject`
- `coda_mdstore.presentation.createBag`
- `coda_mdstore.presentation.updateBag`

This **does not** include tests for:
- `coda_mdstore.presentation.getFileList`
    - "Untestable"*
- `coda_mdstore.presenstation.getFileHandle`
    - "Untestable"*
- `coda_mdstore.presentation.getERC`
    - will be removed
- `coda_mdstore.presentation.getERCSupport`
    - will be removed
- `coda_mdstore.presentation.load_tag_buf`
    - will be removed
- `coda_mdstore.presentation.baginfoToXHTML`
    - will be removed


Issue: #4 

---
* Not that we couldn't actually write a test for this function, but, because the function is so complex, and setting up the test would just as, or more, complex, I am going to claim that it is "untestable"