### PR TITLE
Upgrade URLs

### DIFF
--- a/coda/coda_mdstore/urls.py
+++ b/coda/coda_mdstore/urls.py
@@ -1,35 +1,33 @@
-from django.conf.urls import *
-from .views import AtomSiteNewsFeed
+from django.conf.urls import url, patterns
+from . import views
 from .resourcesync import sitemaps
 
-urlpatterns = patterns(
-    'coda_mdstore.views',
-    # bag urls
-    (r'^bag/$', 'all_bags'),
-    (r'^APP/bag/$', 'app_bag'),
-    (r'^APP/bag/(?P<identifier>.+?)/$', 'app_bag'),
-    (r'^bag/(?P<identifier>.+?)/$', 'bagHTML'),
-    (r'^bag/(?P<identifier>ark:\/\d+\/.+?).urls$', 'bagURLList'),
-    (r'^bag/(?P<identifier>ark:\/\d+\/.+?)/(?P<filePath>.+)$', 'bagProxy'),
-    # stats urls
-    (r'^stats/$', 'stats'),
-    (r'^stats.json$', 'json_stats'),
-    # node urls
-    (r'^APP/node/$', 'app_node'),
-    (r'^APP/node/(?P<identifier>coda-.*\d+)/$', 'app_node'),
-    (r'^node/$', 'showNodeStatus'),
-    (r'^node/(?P<identifier>coda-.*\d+)/$', 'showNodeStatus'),
-    (r'^extidentifier/(?P<identifier>.+?)/$', 'externalIdentifierSearch'),
-    (r'^extidentifier/$', 'externalIdentifierSearch'),
-    (r'^extidentifier.json$', 'externalIdentifierSearchJSON'),
-    (r'^search/$', 'bagFullTextSearchHTML'),
-    # Here's some static pages
-    (r'^about/$', 'about'),
-    (r'^robots.txt$', 'shooRobot'),
-    (r'^feed/$', AtomSiteNewsFeed()),
-    (r'^$', 'index'),
-)
-urlpatterns += patterns('django.contrib.sitemaps.views',
+urlpatterns = [
+    url(r'^bag/$', views.all_bags, name='bag-list'),
+    url(r'^APP/bag/$', views.app_bag, name='app-bag-list'),
+    url(r'^APP/bag/(?P<identifier>.+?)/$', views.app_bag, name='app-bag-detail'),
+    url(r'^bag/(?P<identifier>.+?)/$', views.bagHTML, name='bag-detail'),
+    url(r'^bag/(?P<identifier>ark:\/\d+\/.+?).urls$', views.bagURLList, name='bag-urls'),
+    url(r'^bag/(?P<identifier>ark:\/\d+\/.+?)/(?P<filePath>.+)$', views.bagProxy, name='bag-proxy'),
+    url(r'^stats/$', views.stats, name='stats'),
+    url(r'^stats.json$', views.json_stats, name='stats-json'),
+    url(r'^APP/node/$', views.app_node, name='app-node-list'),
+    url(r'^APP/node/(?P<identifier>coda-.*\d+)/$', views.app_node, name='app-node-list'),
+    url(r'^node/$', views.showNodeStatus, name='node-list'),
+    url(r'^node/(?P<identifier>coda-.*\d+)/$', views.showNodeStatus, name='node-detail'),
+    url(r'^extidentifier/(?P<identifier>.+?)/$', views.externalIdentifierSearch, name='identifier-detail'),
+    url(r'^extidentifier/$', views.externalIdentifierSearch, name='identifier-search'),
+    url(r'^extidentifier.json$', views.externalIdentifierSearchJSON, name='identifier-search-json'),
+    url(r'^search/$', views.bagFullTextSearchHTML, name='search'),
+    url(r'^about/$', views.about, name='about'),
+    url(r'^robots.txt$', views.shooRobot, name='robots'),
+    url(r'^feed/$', views.AtomSiteNewsFeed(), name='feed'),
+    url(r'^$', views.index, name='index'),
+]
+
+
+urlpatterns += patterns(
+    'django.contrib.sitemaps.views',
     (
         r'^resourceindex\.xml$',
         'index',
@@ -47,7 +45,8 @@ urlpatterns += patterns('django.contrib.sitemaps.views',
         },
     ),
 )
-urlpatterns += patterns('coda_mdstore.resourcesync',
+urlpatterns += patterns(
+    'coda_mdstore.resourcesync',
     (
         r'^changelist\.xml$',
         'changelist',

--- a/coda/coda_project/urls.py
+++ b/coda/coda_project/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^oai/$', 'coda_oaipmh.views.index'),
     url(r'', include('premis_event_service.urls')),
-    url(r'', include('coda_replication.urls')),
-    url(r'', include('coda_mdstore.urls')),
-    url(r'', include('coda_validate.urls')),
+    url(r'', include('coda_replication.urls', namespace='replication')),
+    url(r'', include('coda_mdstore.urls', namespace='mdstore')),
+    url(r'', include('coda_validate.urls', namespace='validate')),
 ]

--- a/coda/coda_replication/urls.py
+++ b/coda/coda_replication/urls.py
@@ -1,14 +1,12 @@
-from django.conf.urls import *
+from django.conf.urls import url
+from . import views
 
-urlpatterns = patterns('coda_replication.views',
-#    (r'^servicedocument/$', 'serviceDocument'),
-    (r'^APP/queue/(?P<identifier>ark:\/\d+\/.+?)/$', 'queue'),
-    (r'^APP/queue/$', 'queue'),
-    (r'^queue/$', 'queue_recent'),
-    (r'^queue/(?P<identifier>ark:\/\d+\/.+?)/$', 'queue_html'),
-    (r'^queue/search/$', 'queue_search'),
-    (r'^queue/search.json$', 'queue_search_JSON'),
-    (r'^queue/stats/$', 'queue_stats'),
-#    (r"^robots.txt$", 'shooRobot'),
-#    (r'^$','index'),
-)
+urlpatterns = [
+    url(r'^APP/queue/(?P<identifier>ark:\/\d+\/.+?)/$', views.queue, name='app-detail'),
+    url(r'^APP/queue/$', views.queue, name='app-list'),
+    url(r'^queue/$', views.queue_recent, name='index'),
+    url(r'^queue/(?P<identifier>ark:\/\d+\/.+?)/$', views.queue_html, name='detail'),
+    url(r'^queue/search/$', views.queue_search, name='search'),
+    url(r'^queue/search.json$', views.queue_search_JSON, name='search-json'),
+    url(r'^queue/stats/$', views.queue_stats, name='stats'),
+]

--- a/coda/coda_validate/urls.py
+++ b/coda/coda_validate/urls.py
@@ -1,17 +1,15 @@
-from django.conf.urls import url, patterns, include
-from .models import Validate
-from .views import AtomNextNewsFeed, AtomNextFeedNoServer
+from django.conf.urls import url
+from . import views
 
 
-urlpatterns = patterns(
-    '',
-    (r'^APP/validate/(?P<identifier>.+?)/$', 'coda_validate.views.app_validate'),
-    (r'^APP/validate/$', 'coda_validate.views.app_validate'),
-    (r'^validate/$', 'coda_validate.views.index'),
-    (r'^validate/stats/$', 'coda_validate.views.stats'),
-    (r'^validate/prioritize/$', 'coda_validate.views.prioritize'),
-    url(r'^validate/prioritize.json', 'coda_validate.views.prioritize_json', name='prioritize_json'),
-    (r'^validate/next/$', AtomNextFeedNoServer()),
-    (r'^validate/next/(?P<server>.+)/$', AtomNextNewsFeed()),
-    (r'^validate/(?P<identifier>.+?)/$', 'coda_validate.views.validate'),
-)
+urlpatterns = [
+    url(r'^APP/validate/(?P<identifier>.+?)/$', views.app_validate, name='app-detail'),
+    url(r'^APP/validate/$', views.app_validate, name='app-list'),
+    url(r'^validate/$', views.index, name='index'),
+    url(r'^validate/stats/$', views.stats, name='stats'),
+    url(r'^validate/prioritize/$', views.prioritize, name='prioritize'),
+    url(r'^validate/prioritize.json', views.prioritize_json, name='prioritize-json'),
+    url(r'^validate/next/$', views.AtomNextFeedNoServer(), name='feed-next'),
+    url(r'^validate/next/(?P<server>.+)/$', views.AtomNextNewsFeed(), name='feed-next-server'),
+    url(r'^validate/(?P<identifier>.+?)/$', views.validate, name='detail'),
+]

--- a/coda/templates/coda_validate/validate.html
+++ b/coda/templates/coda_validate/validate.html
@@ -6,7 +6,7 @@ $(document).ready(function() {
     $('#priority').click(function(){
         $.ajax({
             type: "GET",
-            url: "{% url 'prioritize_json' %}",
+            url: "{% url 'prioritize-json' %}",
             data: {'identifier': $(this).attr('name')},
             dataType: "text",
             success: function(response) {


### PR DESCRIPTION
Resolves #14, but also updates the urls for the other apps.

Essentially this converts the old style urls

```python
urlpatterns = patterns(''
    (r'^pattern', 'python.path.to.view'),
    # ....
)
```

To the new style

```python
urlpatterns = [
    url(r'^pattern', python.path.to.view, name='some-url'),
    # ....
]
```

Note that I chose to leave the `resourcesync` URLs as is. I attempted to change them, there was an issue with the sitemaps view.