### PR TITLE
Fix response codes from utility functions

### DIFF
--- a/coda/coda_mdstore/exceptions.py
+++ b/coda/coda_mdstore/exceptions.py
@@ -1,0 +1,7 @@
+
+class MDStoreException(Exception):
+    pass
+
+
+class BadNodeName(MDStoreException):
+    pass

--- a/coda/coda_mdstore/exceptions.py
+++ b/coda/coda_mdstore/exceptions.py
@@ -5,3 +5,7 @@ class MDStoreException(Exception):
 
 class BadNodeName(MDStoreException):
     pass
+
+
+class BadBagName(MDStoreException):
+    pass

--- a/coda/coda_mdstore/presentation.py
+++ b/coda/coda_mdstore/presentation.py
@@ -137,17 +137,12 @@ def updateBag(request):
     contentElement = entryRoot.xpath("*[local-name() = 'content']")[0]
     codaXML = contentElement.xpath("*[local-name() = 'codaXML']")[0]
     bag_name = codaXML.xpath("*[local-name() = 'name']")[0].text.strip()
-    try:
-        bag = Bag.objects.get(name=bag_name)
-    except Exception, e:
-        resp = HttpResponse('Cannot find bag_name')
-        return resp
-    # lets make sure the url id we gave is the same as in the XML
-    if request.path[9:-1] != bag_name:
-        resp = HttpResponse(
-            'The node name supplied in the URL does not match the XML'
-        )
-        return resp
+
+    if bag_name not in request.path:
+        raise exceptions.BadBagName('The bag name supplied in the URL does not match the XML')
+
+    bag = Bag.objects.get(name=bag_name)
+
     # delete old info objects
     old_bag_infos = Bag_Info.objects.filter(bag_name=bag)
     old_bag_infos.delete()

--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -917,15 +917,35 @@ class TestAppBag:
         )
 
     @mock.patch('coda_mdstore.views.updateBag')
-    def test_put_request(self, mock_updateBag, rf):
+    def test_put_request(self, updateBag, rf):
         bag = FullBagFactory.create()
-        mock_updateBag.return_value = bag
+        updateBag.return_value = bag
 
         request = rf.put('/', HTTP_HOST='example.com')
         response = views.app_bag(request, bag.name)
 
         assert response.status_code == 200
         assert response['Content-Type'] == 'application/atom+xml'
+
+    @mock.patch('coda_mdstore.views.updateBag')
+    def test_put_request_returns_not_found(self, updateBag, rf):
+        bag = FullBagFactory.create()
+        updateBag.side_effect = models.Bag.DoesNotExist
+
+        request = rf.put('/', HTTP_HOST='example.com')
+        response = views.app_bag(request, bag.name)
+
+        assert response.status_code == 404
+
+    @mock.patch('coda_mdstore.views.updateBag')
+    def test_put_request_returns_bad_request(self, updateBag, rf):
+        bag = FullBagFactory.create()
+        updateBag.side_effect = exceptions.BadBagName
+
+        request = rf.put('/', HTTP_HOST='example.com')
+        response = views.app_bag(request, bag.name)
+
+        assert response.status_code == 400
 
     def test_delete_request_is_successful(self, rf):
         bag = FullBagFactory.create()

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -925,9 +925,13 @@ def app_bag(request, identifier=None):
         resp['Location'] = loc
         return resp
     elif request.method == 'PUT' and identifier:
-        bagObject = updateBag(request)
-        if type(bagObject) == HttpResponse:
-            return bagObject
+        try:
+            bagObject = updateBag(request)
+        except Bag.DoesNotExist as e:
+            return HttpResponseNotFound(str(e))
+        except exceptions.BadBagName as e:
+            return HttpResponseBadRequest(str(e))
+
         returnXML = objectsToXML(bagObject)
         returnEntry = bagatom.wrapAtom(
             returnXML, bagObject.name, bagObject.name


### PR DESCRIPTION
Fixes #23 

This modifies `coda_mdstore.presentation.updateBag` and `coda_mdstore.presentation.updateNode` to only return a Bag instance or Node instance respectively. As utility functions, they should not be directly influencing the type of the HTTP response the view sends back. Furthermore, we only want a function to return a single type of object (instead of an `HttpResponse` OR a `Bag`/`Node`).

Now `updateBag` and `updateNode` will raise exceptions in the two situations where it would previously return an `HttpResponse`.

1. If the model is not found, a `DoesNotExist`  exception will be allowed to bubble up.
2. If the name of the instance is not in the request path, a `ModelBadName` exception will be raised.

The calling controllers now know how to deal with these exceptions and will return a `404` or `400` response if encountered.