### PR TITLE
Enhancements for Docker Compose Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,30 +29,40 @@ $ docker-compose up -d db
 
 Start the app and run the migrations.
 ```sh
-# start the app
-$ docker-compose up -d
-
 # run the migrations
-$ docker-compose run --rm coda ./manage.py migrate
+$ docker-compose run --rm manage migrate
+
+# start the app
+$ docker-compose up -d app
 
 # Optional: add a superuser in order to log in to the admin interface
-$ docker-compose run --rm web ./manage.py createsuperuser
+$ docker-compose run --rm manage createsuperuser
 ```
 
 The code is in a volume that is shared between your workstation and the coda container, which means any edits you make on your workstation will also be reflected in the Docker container. No need to rebuild the container to pick up changes in the code.
 
-However, if the requirements files change, it is important that you rebuild the coda image for those packages to be installed. This is something that could happen when switching between feature branches, or when pulling updates from the remote.
+However, if the requirements files change, it is important that you rebuild the images for those packages to be installed. This is something that could happen when switching between feature branches, or when pulling updates from the remote.
 
 ```sh
 # stop the app
 $ docker-compose stop
 
-# remove the coda container
-$ docker-compose rm coda
+# remove the app container
+$ docker-compose rm app test manage
 
-# rebuild the coda container
-$ docker-compose build coda
+# rebuild the app, manage, and test containers
+$ docker-compose build 
 
 # start the app
-$ docker-compose up -d
+$ docker-compose up -d app
+```
+
+## Running the tests
+
+```sh
+# On the initial run or if the schema changes
+$ docker-compose run --rm test --create-db
+
+# Subsequent runs
+$ docker-compose run --rm test 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,31 @@ db:
     environment:
         - MYSQL_ROOT_PASSWORD=root
         - MYSQL_DATABASE=coda_local
-coda: 
+
+base:        
     build: .
-    command: python manage.py runserver 0.0.0.0:80
     volumes:
         - .:/app/
+
+app:
+    extends:
+        service: base
+    command: python manage.py runserver 0.0.0.0:80
     ports:
         - "8000:80"
     links:
         - db
 
+test:
+    extends:
+        service: base
+    entrypoint: py.test
+    links:
+        - db
 
+manage:
+    extends:
+        service: base
+    entrypoint: /app/manage.py
+    links:
+        - db


### PR DESCRIPTION
While I was trying to fix the Travis builds for another feature branch, I discovered a way to make running tests and the `manage.py` script much easier.

Instead of overriding the command for the `coda` container via (This is how we have been doing it)

```sh
$ docker-compose run coda ./manage.py check
```

There is now a `manage` service defined in the `docker-compose.yml` that places the `manage.py` script as the entrypoint. This means that the `manage.py` subcommands can be given directly to the service

```sh
$ docker-compose run manage check
$ docker-compose run migration
...
```

The `test` service similarly sets the `py.test` command as the entrypoint
```sh
$ docker-compose test
$ docker-compose test --create-db
```

When the build changes for the  `coda` container (now called `app`), you have to rebuild the `manage`, `app`, and `test`, because they extend from the `base` service which is built from the `Dockerfile` in the root of the project.