### PR TITLE
Remove duplicated functions.

### DIFF
--- a/coda/coda_mdstore/presentation.py
+++ b/coda/coda_mdstore/presentation.py
@@ -299,34 +299,6 @@ def objectsToXML(bagObject):
     return codaXML
 
 
-def getValueByName(node, name):
-    """
-    A helper function to pull the values out of those annoying namespace
-    prefixed tags
-    """
-
-    try:
-        value = node.xpath("*[local-name() = '%s']" % name)[0].text.strip()
-    #prolly should narrow this down
-    except:
-        return None
-    return value
-
-
-def getNodeByName(node, name):
-    """
-    A helper function to pull the values out of those annoying namespace
-    prefixed tags
-    """
-
-    try:
-        childNode = node.xpath("*[local-name() = '%s']" % name)[0]
-    #prolly should narrow this down
-    except:
-        return None
-    return childNode
-
-
 def nodeEntry(node, webRoot=None):
     """
     Form an atom xml for a given node object.

--- a/coda/coda_mdstore/presentation.py
+++ b/coda/coda_mdstore/presentation.py
@@ -1,21 +1,19 @@
-from django.contrib.sites.models import Site
-from django.http import HttpResponse
-from coda_mdstore.models import Bag, Bag_Info, Node, External_Identifier
-from codalib import anvl, APP_AUTHOR
-from pypairtree import pairtree
-from BeautifulSoup import BeautifulSoup as BSoup
-from lxml import etree
-import re
 import os
-import urlparse
+import re
 import urllib
 import urllib2
-import StringIO
-from datetime import datetime
+import urlparse
 
-from codalib.bagatom import (wrapAtom, ATOM, ATOM_NSMAP, BAG, BAG_NSMAP,
-                             getValueByName, getNodeByName)
+from BeautifulSoup import BeautifulSoup as BSoup
+from codalib import APP_AUTHOR
+from codalib.bagatom import wrapAtom, ATOM, ATOM_NSMAP, BAG, BAG_NSMAP
+from datetime import datetime
+from lxml import etree
+from pypairtree import pairtree
+
 from . import exceptions
+from coda_mdstore.models import Bag, Bag_Info, Node, External_Identifier
+
 
 pairtreeCandidateList = [
     "http://example.com/data3/coda-001/store/pairtree_root/",

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -160,48 +160,6 @@ class TestObjectsToXML:
             assert bag_info_xml.countchildren() == 2
 
 
-@pytest.fixture
-def person_xml():
-    return etree.fromstring(
-        """
-        <person>
-            <name>John Doe</name>
-            <age>34</age>
-        </person>
-        """
-    )
-
-
-@pytest.mark.usefixture('person_xml')
-class TestGetValueByName:
-    """
-    Tests for coda_mdstore.presentation.getValueByName.
-    """
-
-    @pytest.mark.parametrize('name, value', [
-        ('name', 'John Doe'),
-        ('age', '34')
-    ])
-    def test_returns_value(self, name, value, person_xml):
-        assert presentation.getValueByName(person_xml, name) == value
-
-
-@pytest.mark.usefixture('person_xml')
-class TestGetNodeByName:
-    """
-    Tests for coda_mdstore.presentation.getNodeByName.
-    """
-
-    @pytest.mark.parametrize('name, value', [
-        ('name', 'John Doe'),
-        ('age', '34')
-    ])
-    def test_returns_node(self, name, value, person_xml):
-        node = presentation.getNodeByName(person_xml, name)
-        assert node.tag == name
-        assert node.text == value
-
-
 class TestNodeEntry:
     """
     Tests for coda_mdstore.presentation.nodeEntry.


### PR DESCRIPTION
`getValueByName` and `getNodeByName` are functions with equivalent
implementations that are already available within the codalib library.