### PR TITLE
Remove ordering for counting validate statuses

### DIFF
--- a/coda/coda_validate/models.py
+++ b/coda/coda_validate/models.py
@@ -10,7 +10,8 @@ class ValidateManager(models.Manager):
 
     def _verified_counts(self):
         return (self.values('last_verified_status')
-                    .annotate(count=models.Count('last_verified_status')))
+                    .annotate(count=models.Count('last_verified_status'))
+                    .order_by())
 
 
 class VerifiedCountsResultFormatter(object):


### PR DESCRIPTION
This should fix an issue of `Validate`'s default ordering by the `added` field causing unexpected results on getting the `last_verified_status` counts for objects.