### PR TITLE
Use MySQL 5.5 in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 db:
-    image: mysql:latest
+    image: mysql:5.5
     environment:
         - MYSQL_ROOT_PASSWORD=root
         - MYSQL_DATABASE=coda_local


### PR DESCRIPTION
This updates the development environment to use MySQL 5.5. The storage engine of the database is set with this [line](https://github.com/unt-libraries/coda/blob/6b5e61178c8c30efde7a0f246320b7e29fac2628/coda/config/settings/base.py) upon creation. It appears that in newer versions of the MySQL (5.7 for sure) this invocation does not work.

This also brings us closer to MariaDB 5.5 (assuming the version numbers correlate).
