### PR TITLE
Remove version from PES requirement.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ codalib==1.0.3
 sqlparse==0.1.18
 django-debug-toolbar==1.4
 
-git+https://github.com/unt-libraries/django-premis-event-service@v1.2.0
+git+https://github.com/unt-libraries/django-premis-event-service
 git+https://github.com/unt-libraries/pypairtree


### PR DESCRIPTION
Tiny PR is ready @runderwood 