### PR TITLE
Fix 110

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.swo
 
 secrets.json
+env/
 .coverage
 htmlcov/*
 

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -495,7 +495,7 @@ def bagHTML(request, identifier):
     try:
         # grab the related premis events from the json search for
         # linked object id
-        event_json_url = 'http://%s/event/search.json?link_object_id=%s' % (
+        event_json_url = 'http://%s/event/search.json?linked_object_id=%s' % (
             request.META.get('HTTP_HOST'), bag
         )
         json_response = urllib2.urlopen(event_json_url)

--- a/coda/templates/mdstore/about.html
+++ b/coda/templates/mdstore/about.html
@@ -47,10 +47,8 @@
         ... etc ...
     ]
 
-    # filter events to a particular bag object by giving a 'link_object_id'
-    $ curl {{ request.META.HTTP_HOST }}/event/search.json?link_object_id=ark:/67531/coda1295
-    # this argument can also be given as merely the coda shortname, like so:
-    $ curl {{ request.META.HTTP_HOST }}/event/search.json?link_object_id=coda1295
+    # filter events to a particular bag object by giving a 'linked_object_id'
+    $ curl {{ request.scheme }}://{{ request.META.HTTP_HOST }}/event/search.json?linked_object_id=ark:/67531/coda1295
     [
         {
             "date": "2013-05-13 14:27:29",

--- a/coda/templates/mdstore/bag_info.html
+++ b/coda/templates/mdstore/bag_info.html
@@ -46,7 +46,7 @@
 <!-- EVENTS HEADER -->
 {% if json_events|length > 0 %}
 
-<h3><i class="icon-link icon-large"></i>There are <a href="http://{{ request.META.HTTP_HOST }}/event/search/?linked_object_id={{ bag }}">{{ json_events.feed.entry|length }} premis events</a> associated with {{ bag }}:</h3>
+<h3><i class="icon-link icon-large"></i>Here are the first <a href="http://{{ request.META.HTTP_HOST }}/event/search/?linked_object_id={{ bag }}">{{ json_events.feed.entry|length }} premis events</a> associated with {{ bag }}:</h3>
 
 
 <table class="table table-striped">
@@ -87,6 +87,6 @@
 
 
 {% else %}
-    <h3><i class="icon-remove icon-large"></i> There are no <em>premis events</em> associated with this bag.</h3>
+    <h3><i class="icon-remove icon-large"></i> There are no <em>premis events</em> associated with {{ bag }}.</h3>
 {% endif %}
 {% endblock %}

--- a/coda/templates/mdstore/bag_info.html
+++ b/coda/templates/mdstore/bag_info.html
@@ -46,7 +46,7 @@
 <!-- EVENTS HEADER -->
 {% if json_events|length > 0 %}
 
-<h3><i class="icon-link icon-large"></i>Here are the first <a href="http://{{ request.META.HTTP_HOST }}/event/search/?linked_object_id={{ bag }}">{{ json_events.feed.entry|length }} premis events</a> associated with {{ bag }}:</h3>
+<h3><i class="icon-link icon-large"></i>There are <a href="http://{{ request.META.HTTP_HOST }}/event/search/?linked_object_id={{ bag }}">{{ json_events.feed.entry|length }} premis events</a> associated with {{ bag }}:</h3>
 
 
 <table class="table table-striped">


### PR DESCRIPTION
This replaces incorrect use of `link_object_id` with `linked_object_id` and tweaks the language of the `bag_info.html` template to reflect the limited number of PREMIS events that will be shown.

These changes assume we are ok with only showing the top 20 results of events on the bag info page as is brought up in #110 . If we want to show them all, we can address that...

@runderwood @vphill do you want to look at this? There are still a couple of things that need looking at in PES related to searching bags with `linked_object_id` for which I created an issue on [PES](https://github.com/unt-libraries/django-premis-event-service/issues/82).