### PR TITLE
Assign bytes and file count correctly from Payload-Oxum for template

### DIFF
--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -485,10 +485,10 @@ def bagHTML(request, identifier):
     bag_info = Bag_Info.objects.filter(bag_name__exact=bag)
     # Put the bag info in a dict
     bag_info_d = dict((info.field_name, info.field_body) for info in bag_info)
-    oxum_count = oxum_size = -1
+    oxum_bytes = oxum_file_count = -1
     try:
         oxum = bag_info_d.get('Payload-Oxum', '')
-        oxum_count, oxum_size = map(int, oxum.split('.', 1))
+        oxum_bytes, oxum_file_count = map(int, oxum.split('.', 1))
     except:
         pass
     try:
@@ -535,8 +535,8 @@ def bagHTML(request, identifier):
         {
             'linked_events': linked_events,
             'total_events': total_events,
-            'payload_oxum_file_count': oxum_count,
-            'payload_oxum_size': oxum_size,
+            'payload_oxum_file_count': oxum_file_count,
+            'payload_oxum_size': oxum_bytes,
             'bag_date': bag_date,
             'bag': bag,
             'bag_info': bag_info_d,

--- a/coda/templates/mdstore/bag_info.html
+++ b/coda/templates/mdstore/bag_info.html
@@ -19,7 +19,7 @@
                 {% elif k == 'External-Identifier' %}
                     <i class="icon-globe"></i> <a href="http://texashistory.unt.edu/{{ v }}">{{ v }}</a>
                 {% elif k == 'Payload-Oxum' %}
-                    <i class="icon-hdd"></i> {{ payload_oxum_size|filesizeformat }}, <i class="icon-file-alt"></i> {{ payload_oxum_file_count }} files
+                    <i class="icon-hdd"></i> {{ payload_oxum_size }} bytes, <i class="icon-file-alt"></i> {{ payload_oxum_file_count }} files
                 {% elif k == 'Bagging-Date' %}
                     <i class="icon-calendar"></i> {{ bag_date|timesince }} ago
                 {% elif k == 'Organization-Address' %}


### PR DESCRIPTION
This is to fix #113. Also, the template was converting byte count using `filesizeformat`, but since we have an adapted size given in the `Bag-Size` field, and because `Payload-Oxum` gives the value in bytes, we will keep it bytes.