### PR TITLE
Proxy downloads

### DIFF
--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -335,7 +335,7 @@ class TestBagProxyView:
         # The mocked value that getFileHandle will return.
         file_handle = mock.Mock()
         file_handle.info().getheader.side_effect = ['text/plain', '255']
-        file_handle.geturl.return_value = 'http://example.com/direct-file.png'
+        file_handle.geturl.return_value = 'http://example.com/direct-file.txt'
 
         self.getFileHandle = mock.Mock(return_value=file_handle)
         monkeypatch.setattr(
@@ -362,7 +362,7 @@ class TestBagProxyView:
 
         assert response['Content-Length'] == '255'
         assert response['Content-Type'] == 'text/plain'
-        assert response['X-REPROXY-URL'] == 'http://example.com/direct-file.png'
+        assert response['X-REPROXY-URL'] == 'http://example.com/direct-file.txt'
         assert response['ETag']
 
     def test_raises_not_found_when_object_not_found(self, rf):

--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -335,6 +335,7 @@ class TestBagProxyView:
         # The mocked value that getFileHandle will return.
         file_handle = mock.Mock()
         file_handle.info().getheader.side_effect = ['text/plain', '255']
+        file_handle.geturl.return_value = 'http://example.com/direct-file.png'
 
         self.getFileHandle = mock.Mock(return_value=file_handle)
         monkeypatch.setattr(
@@ -353,6 +354,16 @@ class TestBagProxyView:
 
         assert response['Content-Length'] == '255'
         assert response['Content-Type'] == 'text/plain'
+
+    @mock.patch.object(settings, 'REPROXY', True)
+    def test_response_has_correct_headers_reproxy(self, rf):
+        request = rf.get('/', HTTP_HOST="example.com")
+        response = views.bagProxy(request, self.bag.name, '/foo/bar')
+
+        assert response['Content-Length'] == '255'
+        assert response['Content-Type'] == 'text/plain'
+        assert response['X-REPROXY-URL'] == 'http://example.com/direct-file.png'
+        assert response['ETag']
 
     def test_raises_not_found_when_object_not_found(self, rf):
         request = rf.get('/')

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -644,7 +644,7 @@ def bagProxy(request, identifier, filePath):
             content_type=handle.info().getheader('Content-Type')
         )
         resp['Content-Length'] = handle.info().getheader('Content-Length')
-        if hasattr(settings, 'REPROXY') and settings.REPROXY:
+        if getattr(settings, 'REPROXY', False):
             # Have a proxy server point the client to where to download
             # the file directly in order to bypass serving through Django.
             resp['X-REPROXY-URL'] = handle.geturl()

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -1,5 +1,7 @@
 import codecs
 import copy
+import uuid
+
 from urllib2 import urlopen
 from urllib import urlencode
 try:
@@ -639,10 +641,17 @@ def bagProxy(request, identifier, filePath):
     handle = getFileHandle(identifier, filePath)
     if handle:
         resp = HttpResponse(
-            FileWrapper(handle),
             content_type=handle.info().getheader('Content-Type')
         )
         resp['Content-Length'] = handle.info().getheader('Content-Length')
+        if hasattr(settings, 'REPROXY') and settings.REPROXY:
+            # Have a proxy server point the client to where to download
+            # the file directly in order to bypass serving through Django.
+            resp['X-REPROXY-URL'] = handle.geturl()
+            resp['ETag'] = '"%s"' % uuid.uuid4().get_hex()
+        else:
+            # Serve the data file through Django.
+            resp.content = FileWrapper(handle)
     else:
         raise Http404
     return resp

--- a/coda/config/settings/base.py
+++ b/coda/config/settings/base.py
@@ -138,3 +138,10 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 VALIDATION_PERIOD = timedelta(days=365)
 
 ARK_NAAN = 67531
+
+# Optional setting to indicate if we are using a proxy server that we want to
+# use to reproxy requests for a bag's static data files (via bagProxy view).
+try:
+    REPROXY = get_secret('REPROXY')
+except ImproperlyConfigured:
+    REPROXY = False


### PR DESCRIPTION
This PR is intended to allow us to serve a bag's data files (via `bagProxy`) by having our proxy server get the data files from directly where they are hosted rather than pull them through Django. This should fix an issue we have when users try to download some larger files.

ping @somexpert @vphill 