### PR TITLE
Test for error if arguments not passed adequately in urls.py

### DIFF
--- a/coda/coda_mdstore/tests/test_urls.py
+++ b/coda/coda_mdstore/tests/test_urls.py
@@ -2,6 +2,8 @@ from django.contrib import sitemaps
 from django.core.urlresolvers import resolve
 from django.conf import settings
 
+import pytest
+
 from coda_mdstore import resourcesync
 from coda_mdstore import views
 
@@ -92,16 +94,25 @@ def test_feed():
     assert resolve('/feed/').func.__class__ == views.AtomSiteNewsFeed
 
 
-def test_resourceindex():
+@pytest.mark.django_db
+def test_resourceindex(client):
     assert resolve('/resourceindex.xml').func == sitemaps.views.index
+    # Verify correct arguments are being passed in urls.py.
+    assert client.get('/resourceindex.xml').status_code == 200
 
 
-def test_resourcelist_section():
+@pytest.mark.django_db
+def test_resourcelist_section(client):
     assert resolve('/resourcelist-001.xml').func == sitemaps.views.sitemap
+    # Verify correct arguments are being passed in urls.py.
+    assert client.get('/resourcelist-001.xml').status_code == 200
 
 
-def test_changelist():
+@pytest.mark.django_db
+def test_changelist(client):
     assert resolve('/changelist.xml').func == resourcesync.changelist
+    # Verify correct arguments are being passed in urls.py.
+    assert client.get('/changelist.xml').status_code == 200
 
 
 def test_capabilitylist():


### PR DESCRIPTION
500 errors could happen but would not be caught by existing tests
if changes made in urls.py for urls that require arguments
to be passed in `url` are no longer being passed as needed.

@madhulika95b @somexpert , what are your opinions on including urls tests such as these for the urls where arguments must be passed in urls.py (which makes them a bit abnormal compared to most of our urls)?

If you think it is worth including such tests, please review. Otherwise, let me know what you think. Thanks!