### PR TITLE
Fix import and Django Debug Toolbar

### DIFF
--- a/coda/config/settings/base.py
+++ b/coda/config/settings/base.py
@@ -98,7 +98,7 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',

--- a/coda/config/settings/local.py
+++ b/coda/config/settings/local.py
@@ -15,6 +15,11 @@ except NameError:
     INSTALLED_APPS = []
 INSTALLED_APPS += ['debug_toolbar']
 
+try:
+    MIDDLEWARE  # noqa
+except NameError:
+    MIDDLEWARE = []
+MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
 
 # Database settings for the Dockerized dev environment.
 # See docker-compose.yml

--- a/coda/config/urls.py
+++ b/coda/config/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib import admin
 from coda_oaipmh import views as oai_views
@@ -12,3 +13,10 @@ urlpatterns = [
     url(r'', include('coda_mdstore.urls')),
     url(r'', include('coda_validate.urls')),
 ]
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        # For Django versions before 2.0:
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns

--- a/coda/config/urls.py
+++ b/coda/config/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url, include
 from django.contrib import admin
-from coda.coda_oaipmh import views as oai_views
+from coda_oaipmh import views as oai_views
 
 admin.autodiscover()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ pytest-flake8
 mock
 factory_boy
 codalib==1.0.3
-sqlparse==0.1.18
-django-debug-toolbar==1.4
+sqlparse==0.2.4
+django-debug-toolbar==1.11
 
 git+https://github.com/unt-libraries/django-premis-event-service
 git+https://github.com/unt-libraries/pypairtree


### PR DESCRIPTION
This is to fix an import that wasn't working in our deployment and to upgrade the Django Debug Toolbar to work with Django 1.11. ping @madhulika95b @somexpert 