### PR TITLE
Avoid 500 error if Node with given identifier does not exist.

### DIFF
--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -672,6 +672,11 @@ class TestShowNodeStatusView:
 
         assert response.status_code == 200
 
+    def test_node_identifier_does_not_exist(self, rf):
+        request = rf.get('/')
+        with pytest.raises(http.Http404):
+            views.showNodeStatus(request, 'wrong_id')
+
     def test_single_node_context(self, client):
         # TODO: Update the URL ordering so that we can get the URL with
         #       reverse.

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -742,7 +742,7 @@ def showNodeStatus(request, identifier=None):
     """
 
     if identifier:
-        node = Node.objects.get(node_name=identifier)
+        node = get_object_or_404(Node, node_name__exact=identifier)
         return render(
             request,
             'mdstore/node.html',


### PR DESCRIPTION
Noticed a 500 error when looking at the py2to3 branch if a Node was requested where the id didn't exist. This error is not specific to this branch, but it is where I ended up fixing it :D...sorry.

