### PR TITLE
Fix ambiguous var

### DIFF
--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -504,7 +504,7 @@ def bagHTML(request, identifier):
             linked_events += this_page
             next_url = json_events.get('feed', {})
             next_url = next_url.get('link', [])
-            next_url = {l.get('rel'): l.get('href') for l in next_url}
+            next_url = {link.get('rel'): link.get('href') for link in next_url}
             next_url = next_url.get('next')
             if next_url:
                 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 BeautifulSoup4==4.8.1
 django~=1.11.28
-httplib2==0.13.0
+httplib2==0.18.0
 lxml==4.2.6
 mysqlclient ==1.3.14
 python-dateutil==2.8.0


### PR DESCRIPTION
This is to fix a Travis build error for ambiguous variable named 'l'. It also makes the recommended version bump of httplib2.