### PR TITLE
Use django-pes 2.0.0 version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ sqlparse==0.3.0
 django-debug-toolbar==1.11
 
 git+https://github.com/unt-libraries/codalib
-git+https://github.com/unt-libraries/django-premis-event-service
+git+https://github.com/unt-libraries/django-premis-event-service@2.0.0
 git+https://github.com/unt-libraries/pypairtree


### PR DESCRIPTION
This PR uses django 1.11 dependency of django-pes. 