### PR TITLE
Remove duplicates from extidenifier.json results

### DIFF
--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -556,6 +556,35 @@ class TestExternalIdentiferSearchJSON:
         assert content[0]['name'] == bag.name
         assert content[0]['oxum'] == '{0}.{1}'.format(bag.size, bag.files)
 
+    def test_with_valid_ark_id_with_duplicates(self, rf):
+        bag = FullBagFactory.create()
+        bag_1 = FullBagFactory.create()
+
+        ext_id_1 = ExternalIdentifierFactory.create(
+            belong_to_bag=bag,
+            value='ark:/%d/metadc000001' % (settings.ARK_NAAN,)
+        )
+        ExternalIdentifierFactory.create(
+            belong_to_bag=bag,
+            value='ark:/%d/metadc000001' % (settings.ARK_NAAN,)
+        )
+        ExternalIdentifierFactory.create(
+            belong_to_bag=bag_1,
+            value='ark:/%d/metadc000001' % (settings.ARK_NAAN,)
+        )
+
+        request = rf.get('/', {'ark': ext_id_1.value})
+        response = views.externalIdentifierSearchJSON(request)
+        content = json.loads(response.content)
+
+        assert len(content) == 2
+        assert 'bagging_date' in content[0]
+        assert content[0]['name'] == bag.name
+        assert content[0]['oxum'] == '{0}.{1}'.format(bag.size, bag.files)
+        assert 'bagging_date' in content[1]
+        assert content[1]['name'] == bag_1.name
+        assert content[1]['oxum'] == '{0}.{1}'.format(bag_1.size, bag_1.files)
+
 
 class TestBagURLListView:
     """

--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -587,9 +587,7 @@ class TestExternalIdentiferSearchJSON:
 
     def test_with_valid_ark_id_no_showAll(self, rf):
         bag = FullBagFactory.create(bagging_date='2015-01-01')
-#        bag.bagging_date = '2015-01-01'
         bag_1 = FullBagFactory.create(bagging_date='2020-01-01')
-#        bag_1.bagging_date = '2020-01-01'
         external_id = 'ark:/%d/metadc000001' % (settings.ARK_NAAN,)
         ExternalIdentifierFactory.create(
             belong_to_bag=bag,

--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -556,24 +556,24 @@ class TestExternalIdentiferSearchJSON:
         assert content[0]['name'] == bag.name
         assert content[0]['oxum'] == '{0}.{1}'.format(bag.size, bag.files)
 
-    def test_with_valid_ark_id_with_duplicates(self, rf):
+    def test_with_valid_ark_id_showAll_with_duplicates(self, rf):
         bag = FullBagFactory.create()
         bag_1 = FullBagFactory.create()
+        external_id = 'ark:/%d/metadc000001' % (settings.ARK_NAAN,)
 
-        ext_id_1 = ExternalIdentifierFactory.create(
+        ExternalIdentifierFactory.create(
             belong_to_bag=bag,
-            value='ark:/%d/metadc000001' % (settings.ARK_NAAN,)
+            value=external_id
         )
         ExternalIdentifierFactory.create(
             belong_to_bag=bag,
-            value='ark:/%d/metadc000001' % (settings.ARK_NAAN,)
+            value=external_id
         )
         ExternalIdentifierFactory.create(
             belong_to_bag=bag_1,
-            value='ark:/%d/metadc000001' % (settings.ARK_NAAN,)
+            value=external_id
         )
-
-        request = rf.get('/', {'ark': ext_id_1.value})
+        request = rf.get('/', {'ark': external_id, 'showAll': True})
         response = views.externalIdentifierSearchJSON(request)
         content = json.loads(response.content)
 
@@ -584,6 +584,29 @@ class TestExternalIdentiferSearchJSON:
         assert 'bagging_date' in content[1]
         assert content[1]['name'] == bag_1.name
         assert content[1]['oxum'] == '{0}.{1}'.format(bag_1.size, bag_1.files)
+
+    def test_with_valid_ark_id_no_showAll(self, rf):
+        bag = FullBagFactory.create(bagging_date='2015-01-01')
+#        bag.bagging_date = '2015-01-01'
+        bag_1 = FullBagFactory.create(bagging_date='2020-01-01')
+#        bag_1.bagging_date = '2020-01-01'
+        external_id = 'ark:/%d/metadc000001' % (settings.ARK_NAAN,)
+        ExternalIdentifierFactory.create(
+            belong_to_bag=bag,
+            value=external_id
+        )
+        ExternalIdentifierFactory.create(
+            belong_to_bag=bag_1,
+            value=external_id
+        )
+        request = rf.get('/', {'ark': external_id})
+        response = views.externalIdentifierSearchJSON(request)
+        content = json.loads(response.content)
+
+        assert len(content) == 1
+        assert 'bagging_date' in content[0]
+        assert content[0]['name'] == bag_1.name
+        assert content[0]['oxum'] == '{0}.{1}'.format(bag_1.size, bag_1.files)
 
 
 class TestBagURLListView:

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -675,16 +675,19 @@ def externalIdentifierSearchJSON(request):
 
     identifiers = (External_Identifier.objects
                                       .select_related('belong_to_bag')
-                                      .filter(value=ark)
-                                      .distinct())
-    data = [
-        {
-            'name': exid.belong_to_bag.name,
-            'oxum': exid.belong_to_bag.oxum,
-            'bagging_date': exid.belong_to_bag.bagging_date.strftime('%Y-%m-%d')
-        }
-        for exid in identifiers
-    ]
+                                      .filter(value=ark))
+    unique_identifiers = []
+    data = []
+    for bagInfoObject in identifiers:
+        bag = bagInfoObject.belong_to_bag
+        if bag not in unique_identifiers:
+            unique_identifiers.append(bag)
+            data.append(
+                {
+                    'name': bag.name,
+                    'oxum': bag.oxum,
+                    'bagging_date': bag.bagging_date.strftime('%Y-%m-%d')
+                })
 
     data = json.dumps(data, indent=4, sort_keys=True)
     return HttpResponse(data, content_type='application/json')

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -670,24 +670,44 @@ def externalIdentifierSearch(request, identifier=None):
 def externalIdentifierSearchJSON(request):
     """External_Identifier search formatted in JSON."""
     ark = request.GET.get('ark', '')
+    showAll = request.GET.get('showAll', False)
     if ('ark:/%d' % settings.ARK_NAAN) not in ark:
         ark = 'ark:/%d/%s' % (settings.ARK_NAAN, ark)
-
-    identifiers = (External_Identifier.objects
-                                      .select_related('belong_to_bag')
-                                      .filter(value=ark))
-    unique_identifiers = []
     data = []
-    for bagInfoObject in identifiers:
-        bag = bagInfoObject.belong_to_bag
-        if bag not in unique_identifiers:
-            unique_identifiers.append(bag)
-            data.append(
+    if not showAll:
+        identifiers = (External_Identifier.objects
+                                          .select_related('belong_to_bag')
+                                          .filter(value=ark)
+                                          .order_by('-belong_to_bag__bagging_date')
+                                          .first())
+        if identifiers:
+            data = [
                 {
-                    'name': bag.name,
-                    'oxum': bag.oxum,
-                    'bagging_date': bag.bagging_date.strftime('%Y-%m-%d')
-                })
+                    'name': identifiers.belong_to_bag.name,
+                    'oxum': identifiers.belong_to_bag.oxum,
+                    'bagging_date': identifiers.belong_to_bag.bagging_date.strftime('%Y-%m-%d')
+                }
+            ]
+
+    else:
+        identifiers = (External_Identifier.objects
+                                          .select_related('belong_to_bag')
+                                          .filter(value=ark)
+                                          .values_list('belong_to_bag__name',
+                                                       'belong_to_bag__size',
+                                                       'belong_to_bag__files',
+                                                       'belong_to_bag__bagging_date')
+                                          .distinct()
+                                          .order_by('-belong_to_bag__bagging_date'))
+
+        data = [
+            {
+                'name': exid[0],
+                'oxum': '%s.%s' % (exid[1], exid[2]),
+                'bagging_date': exid[3].strftime('%Y-%m-%d')
+            }
+            for exid in identifiers
+        ]
 
     data = json.dumps(data, indent=4, sort_keys=True)
     return HttpResponse(data, content_type='application/json')


### PR DESCRIPTION
@ldko 

This closes #146 #145 
`distinct()` on filtered `ExternalIdentifierFactory` objects doesn't seem to remove duplicates from `externalIdentifierSearchJSON` view. Probably `distinct()` is considering them as distinct objects because they are all given unique ids. So, I added the same logic used in `externalIdentifierSearch` view to remove duplicates.