### PR TITLE
Replace removed `getheader` call

### DIFF
--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -334,7 +334,7 @@ class TestBagProxyView:
 
         # The mocked value that getFileHandle will return.
         file_handle = mock.Mock()
-        file_handle.info().getheader.side_effect = ['text/plain', '255']
+        file_handle.info().get.side_effect = ['text/plain', '255']
         file_handle.geturl.return_value = 'http://example.com/direct-file.txt'
 
         self.getFileHandle = mock.Mock(return_value=file_handle)
@@ -618,7 +618,7 @@ class TestBagURLListView:
 
         # The mocked value that getFileHandle will return.
         file_handle = mock.Mock()
-        file_handle.info().getheader.side_effect = ['text/plain', '255']
+        file_handle.info().get.side_effect = ['text/plain', '255']
 
         self.getFileHandle = mock.Mock(return_value=file_handle)
         monkeypatch.setattr(

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -604,9 +604,9 @@ def bagProxy(request, identifier, filePath):
     handle = getFileHandle(identifier, filePath)
     if handle:
         resp = HttpResponse(
-            content_type=handle.info().getheader('Content-Type')
+            content_type=handle.info().get('Content-Type')
         )
-        resp['Content-Length'] = handle.info().getheader('Content-Length')
+        resp['Content-Length'] = handle.info().get('Content-Length')
         if getattr(settings, 'REPROXY', False):
             # Have a proxy server point the client to where to download
             # the file directly in order to bypass serving through Django.


### PR DESCRIPTION
Running coda in the Docker Python 3.7 environment, view `bagProxy` errors with: `'HTTPMessage' object has no attribute 'getheader'` due to `getheader` having been removed. This should fix that.

This is ready for review @madhulika95b @somexpert .