### PR TITLE
Fix intermittent status test fail

### DIFF
--- a/coda/coda_replication/tests/test_views.py
+++ b/coda/coda_replication/tests/test_views.py
@@ -102,18 +102,16 @@ class TestQueueSearch:
 
     def test_filtering_by_status(self, client):
         status = '2'
-        entries = factories.QueueEntryFactory.create_batch(100)
-
-        # Make sure at least one QueueFactory with the status exists.
-        entries_with_status = factories.QueueEntryFactory.create_batch(1, status=status)
-        entries += entries_with_status
+        status_count = 5
+        factories.QueueEntryFactory.create_batch(status_count, status=status)
+        factories.QueueEntryFactory.create_batch(7, status='1')
 
         response = client.get(
             reverse('replication-search'),
             {'status': status})
 
         results = response.context['entries']
-        assert sum(q.status == status for q in entries) == len(results.object_list)
+        assert len(results.object_list) == status_count
 
     def test_sorting_by_size(self, client):
         """


### PR DESCRIPTION
After last merge into master, this test failed (had not failed in CI check during PR) which highlighted that the test intermittently fails if the number of entries created with `status` of 2 was greater than 20 because of pagination breaking entries at 20. This change explicitly sets the number of entries with and without a `status` of '2' and keeps them below the pagination number.

This is ready for review @madhulika95b @somexpert .