### PR TITLE
Edit bagurl view

### DIFF
--- a/coda/coda_mdstore/presentation.py
+++ b/coda/coda_mdstore/presentation.py
@@ -22,6 +22,10 @@ XHTML = "{%s}" % XHTML_NAMESPACE
 XHTML_NSMAP = {None: XHTML_NAMESPACE}
 
 
+class FileHandleError(Exception):
+    pass
+
+
 def getFileList(url):
     """
     Use BeautifulSoup to get a List of Files
@@ -76,7 +80,7 @@ def getFileHandle(codaId, codaPath):
         except Exception as e:
             exceptionList.append(str(e))
             pass
-    raise Exception(
+    raise FileHandleError(
         "Unable to get handle for id %s at path %s" % (codaId, codaPath)
     )
 
@@ -87,11 +91,10 @@ def generateBagFiles(identifier, proxyRoot, proxyMode):
     """
     pathList = []
     transList = []
-    handle = getFileHandle(identifier, "manifest-md5.txt")
-    if not handle:
-        raise Exception(
-            "Unable to get handle for id %s" % (identifier)
-        )
+    try:
+        handle = getFileHandle(identifier, "manifest-md5.txt")
+    except FileHandleError:
+        raise FileHandleError("Unable to get handle for id %s" % (identifier))
     bag_root = handle.url.rsplit('/', 1)[0]
     line = handle.readline()
     # iterate over handle and append urls to pathlist

--- a/coda/coda_mdstore/presentation.py
+++ b/coda/coda_mdstore/presentation.py
@@ -82,18 +82,23 @@ def getFileHandle(codaId, codaPath):
 
 
 def generateBagFiles(identifier, proxyRoot, proxyMode):
+    """
+    Return list of files in the bag
+    """
     pathList = []
     transList = []
     handle = getFileHandle(identifier, "manifest-md5.txt")
     if not handle:
-        return 'Http404'
+        raise Exception(
+            "Unable to get handle for id %s" % (identifier)
+        )
     bag_root = handle.url.rsplit('/', 1)[0]
     line = handle.readline()
     # iterate over handle and append urls to pathlist
     while line:
         line = line.strip()
         parts = line.split(None, 1)
-        if len(parts) > 1:
+        if len(parts) == 2:
             pathList.append(parts[1])
         line = handle.readline()
     # iterate top files and append to pathlist

--- a/coda/coda_mdstore/presentation.py
+++ b/coda/coda_mdstore/presentation.py
@@ -91,10 +91,7 @@ def generateBagFiles(identifier, proxyRoot, proxyMode):
     """
     pathList = []
     transList = []
-    try:
-        handle = getFileHandle(identifier, "manifest-md5.txt")
-    except FileHandleError:
-        raise FileHandleError("Unable to get handle for id %s" % (identifier))
+    handle = getFileHandle(identifier, "manifest-md5.txt")
     bag_root = handle.url.rsplit('/', 1)[0]
     line = handle.readline()
     # iterate over handle and append urls to pathlist
@@ -110,7 +107,7 @@ def generateBagFiles(identifier, proxyRoot, proxyMode):
         topFiles = getFileList(topFileHandle.url)
         for topFile in topFiles:
             pathList.append(topFile)
-    except:
+    except FileHandleError:
         pass
     # iterate pathlist and resolve a unicode path dependent on proxy mode
     for path in pathList:

--- a/coda/coda_mdstore/tests/test_urls.py
+++ b/coda/coda_mdstore/tests/test_urls.py
@@ -32,12 +32,12 @@ def test_bagURLList():
     assert resolve('/bag/ark:/%d/coda2.urls' % settings.ARK_NAAN).func == views.bagURLList
 
 
-def test_bagURLList_zip_download():
-    assert resolve('/bag/ark:/%d/coda2.zip' % settings.ARK_NAAN).func == views.bagURLList
+def test_bag_zip_download():
+    assert resolve('/bag/ark:/%d/coda2.zip' % settings.ARK_NAAN).func == views.bagDownload
 
 
-def test_bagURLList_with_links():
-    assert resolve('/bag/ark:/%d/coda2/links/' % settings.ARK_NAAN).func == views.bagURLList
+def test_bag_links():
+    assert resolve('/bag/ark:/%d/coda2/links/' % settings.ARK_NAAN).func == views.bagURLLinks
 
 
 def test_bagProxy():

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -670,8 +670,10 @@ class TestGenerateBagFiles:
                                           proxyMode=True)
             assert str(exc.value) == 'Unable to get handle for id %s' % (identifier)
 
+    @mock.patch('coda_mdstore.presentation.getFileList')
     @mock.patch('coda_mdstore.presentation.getFileHandle')
-    def test_bag_files_with_proxyroot(self, mock_handle):
+    def test_bag_files_with_proxyroot(self, mock_handle, mock_file_list):
+        mock_file_list.return_value = ['bagit.txt', 'bag-info.txt']
         mock_handle.return_value.readline.side_effect = [
             b'192e635b17a9c2aea6181f0f87cab05d  data/file01.txt',
             b'18b7c500ef8bacf7b2151f83d28e7ca1  data/file02.txt',
@@ -681,7 +683,9 @@ class TestGenerateBagFiles:
                                                   proxyRoot='https://example.com/',
                                                   proxyMode=True)
         assert transList == ['https://example.com/bag/ark:/67531/coda1/data/file01.txt',
-                             'https://example.com/bag/ark:/67531/coda1/data/file02.txt']
+                             'https://example.com/bag/ark:/67531/coda1/data/file02.txt',
+                             'https://example.com/bag/ark:/67531/coda1/bagit.txt',
+                             'https://example.com/bag/ark:/67531/coda1/bag-info.txt']
         assert mock_handle.call_count == 2
 
     @mock.patch('coda_mdstore.presentation.getFileList')

--- a/coda/coda_mdstore/tests/test_utils.py
+++ b/coda/coda_mdstore/tests/test_utils.py
@@ -662,9 +662,9 @@ class TestGenerateBagFiles:
     """
     @mock.patch('coda_mdstore.presentation.getFileHandle')
     def test_file_handle_error(self, mock_handle):
-        mock_handle.return_value = None
+        mock_handle.side_effect = presentation.FileHandleError()
         identifier = 'ark:/%d/coda2' % settings.ARK_NAAN
-        with pytest.raises(Exception) as exc:
+        with pytest.raises(presentation.FileHandleError) as exc:
             presentation.generateBagFiles(identifier=identifier,
                                           proxyRoot='',
                                           proxyMode=True)
@@ -731,7 +731,7 @@ class TestGetFileHandle:
     def test_getFileHandle_no_node(self):
         codaId = 'ark:/67531/coda1s9ns'
         codaPath = 'manifest.txt'
-        with pytest.raises(Exception) as exc:
+        with pytest.raises(presentation.FileHandleError) as exc:
             presentation.getFileHandle(codaId=codaId, codaPath=codaPath)
             assert str(exc.value) == 'Unable to get handle for id %s at path %s'\
                    % (codaId, codaPath)

--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -367,10 +367,8 @@ class TestBagProxyView:
 
     def test_raises_not_found_when_object_not_found(self, rf):
         request = rf.get('/')
-        response = views.bagProxy(request, 'ark:/00002/id', '/foo/bar')
-
-        assert response.status_code == 404
-        assert response.content == b"There is no bag with id 'ark:/00002/id'."
+        with pytest.raises(http.Http404):
+            views.bagProxy(request, 'ark:/00002/id', '/foo/bar')
 
     def test_raises_http404_when_file_handle_is_false(self, rf):
         self.getFileHandle.return_value = False

--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -13,7 +13,7 @@ from django import http
 from coda_mdstore import views, models, exceptions
 from coda_mdstore.factories import FullBagFactory, NodeFactory, ExternalIdentifierFactory
 from coda_mdstore.tests import CODA_XML
-
+from coda_mdstore.presentation import FileHandleError
 
 pytestmark = pytest.mark.django_db()
 
@@ -618,7 +618,7 @@ class TestBagURLListView:
 
     @mock.patch('coda_mdstore.views.generateBagFiles')
     def test_raises_http404_file_handle_is_falsy(self, mock_bag_files, rf):
-        mock_bag_files.side_effect = Exception()
+        mock_bag_files.side_effect = FileHandleError()
         bag = FullBagFactory.create()
         request = rf.get('/')
         with pytest.raises(http.Http404):

--- a/coda/coda_mdstore/tests/test_views.py
+++ b/coda/coda_mdstore/tests/test_views.py
@@ -615,14 +615,12 @@ class TestBagURLListView:
     def test_raises_not_found_when_object_not_found(self, rf):
         identifier = 'ark:/00002/id'
         request = rf.get('/')
-        response = views.bagURLList(request, identifier)
-        assert isinstance(response, http.HttpResponseNotFound)
-        assert response.content == 'There is no bag with id {0}.' \
-            .format(identifier).encode()
+        with pytest.raises(http.Http404):
+            views.bagURLList(request, identifier)
 
     @mock.patch('coda_mdstore.views.generateBagFiles')
     def test_raises_http404_file_handle_is_falsy(self, mock_bag_files, rf):
-        mock_bag_files.return_value = 'Http404'
+        mock_bag_files.side_effect = Exception()
         bag = FullBagFactory.create()
         request = rf.get('/')
         with pytest.raises(http.Http404):

--- a/coda/coda_mdstore/urls.py
+++ b/coda/coda_mdstore/urls.py
@@ -8,12 +8,12 @@ urlpatterns = [
     re_path(r'^APP/bag/$', views.app_bag, name='app-bag-list'),
     re_path(r'^APP/bag/(?P<identifier>.+?)/$', views.app_bag, name='app-bag-detail'),
     re_path(
-        r'^bag/(?P<identifier>ark:\/\d+\/.+?)/links/$', views.bagURLList,
-        kwargs={'html': True}, name='bag-links'
+        r'^bag/(?P<identifier>ark:\/\d+\/.+?)/links/$', views.bagURLLinks,
+        name='bag-links'
     ),
     re_path(
-        r'^bag/(?P<identifier>ark:\/\d+\/.+).zip$', views.bagURLList,
-        kwargs={'download': True}, name='bag-download'
+        r'^bag/(?P<identifier>ark:\/\d+\/.+).zip$', views.bagDownload,
+        name='bag-download'
     ),
     re_path(r'^bag/(?P<identifier>.+?)/$', views.bagHTML, name='bag-detail'),
     re_path(r'^bag/(?P<identifier>ark:\/\d+\/.+?).urls$', views.bagURLList, name='bag-urls'),

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -20,9 +20,9 @@ from coda_replication.models import QueueEntry
 from coda_validate.models import Validate
 from .models import Bag, Bag_Info, Node, External_Identifier
 from codalib import APP_AUTHOR, bagatom
-from .presentation import getFileList, getFileHandle, bagSearch, \
+from .presentation import getFileHandle, bagSearch, \
     makeBagAtomFeed, createBag, updateBag, objectsToXML, updateNode, \
-    nodeEntry, createNode, zip_file_streamer
+    nodeEntry, createNode, zip_file_streamer, generateBagFiles
 from dateutil import rrule
 from datetime import datetime
 # for historical reasons that are not entirely clear, the tests for
@@ -532,15 +532,13 @@ def bagHTML(request, identifier):
     )
 
 
-def bagURLList(request, identifier, html=False, download=False):
+def bagURLList(request, identifier):
     """
     Return a list of URLS in the bag
     """
 
     # assign the proxy url
     proxyRoot = "http://%s/" % request.META.get('HTTP_HOST')
-    pathList = []
-    transList = []
     # attempt to grab a bag,
     try:
         Bag.objects.get(name=identifier)
@@ -548,59 +546,60 @@ def bagURLList(request, identifier, html=False, download=False):
         return HttpResponseNotFound(
             "There is no bag with id {0}.".format(identifier)
         )
-    handle = getFileHandle(identifier, "manifest-md5.txt")
-    if not handle:
+    transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
+    if transList == 'Http404':
         raise Http404
-    bag_root = handle.url.rsplit('/', 1)[0]
-    line = handle.readline()
-    # iterate over handle and append urls to pathlist
-    while line:
-        line = line.strip()
-        parts = line.split(None, 1)
-        if len(parts) > 1:
-            pathList.append(parts[1])
-        line = handle.readline()
-    # iterate top files and append to pathlist
-    try:
-        topFileHandle = getFileHandle(identifier, "")
-        topFiles = getFileList(topFileHandle.url)
-        for topFile in topFiles:
-            pathList.append(topFile)
-    except:
-        pass
-    # iterate pathlist and resolve a unicode path dependent on proxy mode
-    for path in pathList:
-        if isinstance(path, bytes):
-            try:
-                path = path.decode()
-            except UnicodeDecodeError:
-                path = path.decode('latin-1')
-        # CODA_PROXY_MODE is a settings variable
-        if settings.CODA_PROXY_MODE:
-            uni = '%sbag/%s/%s' % (
-                proxyRoot, identifier, path
-            )
-        else:
-            uni = bag_root + "/" + path
-        # throw the final path into a list
-        transList.append(uni)
-
-    if html:
-        return render(request, 'mdstore/bag_files_download.html',
-                      {'links': sorted(transList)})
-
-    if download:
-        meta_id = identifier.split('/')[-1]
-        zip_filename = meta_id + '.zip'
-        response = StreamingHttpResponse(zip_file_streamer(transList, meta_id),
-                                         content_type='application/zip')
-        response['Content-Disposition'] = 'attachment; filename=%s' % zip_filename
-        return response
 
     outputText = "\n".join(reversed(transList))
     resp = HttpResponse(outputText, content_type="text/plain")
     resp.status_code = 200
     return resp
+
+
+def bagURLLinks(request, identifier):
+    """
+        Return links to URLS in the bag
+    """
+    # assign the proxy url
+    proxyRoot = "http://%s/" % request.META.get('HTTP_HOST')
+    # attempt to grab a bag,
+    try:
+        Bag.objects.get(name=identifier)
+    except Bag.DoesNotExist:
+        return HttpResponseNotFound(
+            "There is no bag with id {0}.".format(identifier)
+        )
+    transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
+    if transList == 'Http404':
+        raise Http404
+
+    return render(request, 'mdstore/bag_files_download.html',
+                  {'links': sorted(transList)})
+
+
+def bagDownload(request, identifier):
+    """
+        Return a downloadable bag zipped file.
+    """
+    # assign the proxy url
+    proxyRoot = "http://%s/" % request.META.get('HTTP_HOST')
+    # attempt to grab a bag,
+    try:
+        Bag.objects.get(name=identifier)
+    except Bag.DoesNotExist:
+        return HttpResponseNotFound(
+            "There is no bag with id {0}.".format(identifier)
+        )
+    transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
+    if transList == 'Http404':
+        raise Http404
+
+    meta_id = identifier.split('/')[-1]
+    zip_filename = meta_id + '.zip'
+    response = StreamingHttpResponse(zip_file_streamer(transList, meta_id),
+                                     content_type='application/zip')
+    response['Content-Disposition'] = 'attachment; filename=%s' % zip_filename
+    return response
 
 
 def bagProxy(request, identifier, filePath):

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -593,12 +593,7 @@ def bagProxy(request, identifier, filePath):
     Attempt to proxy a file from within the given bag
     """
 
-    try:
-        Bag.objects.get(name=identifier)
-    except Bag.DoesNotExist:
-        return HttpResponseNotFound(
-            "There is no bag with id '%s'." % identifier
-        )
+    get_object_or_404(Bag, name__exact=identifier)
     handle = getFileHandle(identifier, filePath)
     if handle:
         resp = HttpResponse(

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -538,16 +538,12 @@ def bagURLList(request, identifier):
     """
 
     # assign the proxy url
-    proxyRoot = "http://%s/" % request.META.get('HTTP_HOST')
+    proxyRoot = request.build_absolute_uri('/')
     # attempt to grab a bag,
+    get_object_or_404(Bag, name__exact=identifier)
     try:
-        Bag.objects.get(name=identifier)
-    except Bag.DoesNotExist:
-        return HttpResponseNotFound(
-            "There is no bag with id {0}.".format(identifier)
-        )
-    transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
-    if transList == 'Http404':
+        transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
+    except Exception:
         raise Http404
 
     outputText = "\n".join(reversed(transList))
@@ -561,18 +557,13 @@ def bagURLLinks(request, identifier):
         Return links to URLS in the bag
     """
     # assign the proxy url
-    proxyRoot = "http://%s/" % request.META.get('HTTP_HOST')
+    proxyRoot = request.build_absolute_uri('/')
     # attempt to grab a bag,
+    get_object_or_404(Bag, name__exact=identifier)
     try:
-        Bag.objects.get(name=identifier)
-    except Bag.DoesNotExist:
-        return HttpResponseNotFound(
-            "There is no bag with id {0}.".format(identifier)
-        )
-    transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
-    if transList == 'Http404':
+        transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
+    except Exception:
         raise Http404
-
     return render(request, 'mdstore/bag_files_download.html',
                   {'links': sorted(transList)})
 
@@ -582,18 +573,13 @@ def bagDownload(request, identifier):
         Return a downloadable bag zipped file.
     """
     # assign the proxy url
-    proxyRoot = "http://%s/" % request.META.get('HTTP_HOST')
+    proxyRoot = request.build_absolute_uri('/')
     # attempt to grab a bag,
+    get_object_or_404(Bag, name__exact=identifier)
     try:
-        Bag.objects.get(name=identifier)
-    except Bag.DoesNotExist:
-        return HttpResponseNotFound(
-            "There is no bag with id {0}.".format(identifier)
-        )
-    transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
-    if transList == 'Http404':
+        transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
+    except Exception:
         raise Http404
-
     meta_id = identifier.split('/')[-1]
     zip_filename = meta_id + '.zip'
     response = StreamingHttpResponse(zip_file_streamer(transList, meta_id),

--- a/coda/coda_mdstore/views.py
+++ b/coda/coda_mdstore/views.py
@@ -22,7 +22,7 @@ from .models import Bag, Bag_Info, Node, External_Identifier
 from codalib import APP_AUTHOR, bagatom
 from .presentation import getFileHandle, bagSearch, \
     makeBagAtomFeed, createBag, updateBag, objectsToXML, updateNode, \
-    nodeEntry, createNode, zip_file_streamer, generateBagFiles
+    nodeEntry, createNode, zip_file_streamer, generateBagFiles, FileHandleError
 from dateutil import rrule
 from datetime import datetime
 # for historical reasons that are not entirely clear, the tests for
@@ -543,7 +543,7 @@ def bagURLList(request, identifier):
     get_object_or_404(Bag, name__exact=identifier)
     try:
         transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
-    except Exception:
+    except FileHandleError:
         raise Http404
 
     outputText = "\n".join(reversed(transList))
@@ -562,7 +562,7 @@ def bagURLLinks(request, identifier):
     get_object_or_404(Bag, name__exact=identifier)
     try:
         transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
-    except Exception:
+    except FileHandleError:
         raise Http404
     return render(request, 'mdstore/bag_files_download.html',
                   {'links': sorted(transList)})
@@ -578,7 +578,7 @@ def bagDownload(request, identifier):
     get_object_or_404(Bag, name__exact=identifier)
     try:
         transList = generateBagFiles(identifier, proxyRoot, settings.CODA_PROXY_MODE)
-    except Exception:
+    except FileHandleError:
         raise Http404
     meta_id = identifier.split('/')[-1]
     zip_filename = meta_id + '.zip'


### PR DESCRIPTION
@ldko @somexpert 
This PR moves the bag files generations logic from views to presentation and also adds separate views to handle bag file urls, bag file links and zipped bag download.

Added tests to the newly added function and also `getFileHandle` in `presentation.py` which was missing tests. 