### PR TITLE
Add allowZip64 setting

### DIFF
--- a/coda/coda_mdstore/presentation.py
+++ b/coda/coda_mdstore/presentation.py
@@ -96,7 +96,7 @@ def zip_file_streamer(urls, meta_id):
     """
     Stream zipped file using zipstream
     """
-    with zipstream.ZipFile(mode='w') as zip_obj:
+    with zipstream.ZipFile(mode='w', allowZip64=True) as zip_obj:
         for url in urls:
             filename = '%s/%s' % (meta_id, url.split(meta_id, 1)[-1])
 


### PR DESCRIPTION
@ldko @somexpert 
This PR prevents corrupt zipped bag downloads when the bag size is greater than 4G by adding `allowZip64` setting.