### PR TITLE
Update about page

### DIFF
--- a/coda/templates/mdstore/about.html
+++ b/coda/templates/mdstore/about.html
@@ -15,7 +15,7 @@
     <!--BEGIN CODE MARKUP-->
     <div id="highlight-python"><pre>
     # to get only the events which have failed, use the 'outcome' url argument
-    $ curl {{ request.META.HTTP_HOST }}/event/search.json?event_outcome=http%3A%2F%2Fpurl.org%2Fnet%2Funtl%2Fvocabularies%2FeventOutcomes%2F%23failure
+    $ curl {{ request.META.HTTP_HOST }}/event/search.json?event_outcome=http://purl.org/net/untl/vocabularies/eventOutcomes/%23failure
     [
         {
             "date": "2013-05-13 14:27:29",
@@ -35,7 +35,7 @@
     ]
 
     # to get the events which failed after a certain date, append a 'start_date' argument
-    $ curl {{ request.META.HTTP_HOST }}/event/search.json?event_outcome=http%3A%2F%2Fpurl.org%2Fnet%2Funtl%2Fvocabularies%2FeventOutcomes%2F%23failure&start_date=05%2F13%2F2013
+    $ curl {{ request.META.HTTP_HOST }}/event/search.json?event_outcome=http://purl.org/net/untl/vocabularies/eventOutcomes/%23failure&start_date=05/13/2013
 
     [
         {

--- a/coda/templates/mdstore/about.html
+++ b/coda/templates/mdstore/about.html
@@ -15,7 +15,7 @@
     <!--BEGIN CODE MARKUP-->
     <div id="highlight-python"><pre>
     # to get only the events which have failed, use the 'outcome' url argument
-    $ curl {{ request.META.HTTP_HOST }}/event/search.json?outcome=http://purl.org/net/untl/vocabularies/eventOutcomes#failure
+    $ curl {{ request.META.HTTP_HOST }}/event/search.json?event_outcome=http%3A%2F%2Fpurl.org%2Fnet%2Funtl%2Fvocabularies%2FeventOutcomes%2F%23failure
     [
         {
             "date": "2013-05-13 14:27:29",
@@ -35,7 +35,8 @@
     ]
 
     # to get the events which failed after a certain date, append a 'start_date' argument
-    $ curl {{ request.META.HTTP_HOST }}/event/search.json?outcome=http://purl.org/net/untl/vocabularies/eventOutcomes#failure&start_date=05/13/2013
+    $ curl {{ request.META.HTTP_HOST }}/event/search.json?event_outcome=http%3A%2F%2Fpurl.org%2Fnet%2Funtl%2Fvocabularies%2FeventOutcomes%2F%23failure&start_date=05%2F13%2F2013
+
     [
         {
             "date": "2013-05-13 14:27:30",

--- a/coda/templates/mdstore/about.html
+++ b/coda/templates/mdstore/about.html
@@ -15,7 +15,7 @@
     <!--BEGIN CODE MARKUP-->
     <div id="highlight-python"><pre>
     # to get only the events which have failed, use the 'outcome' url argument
-    $ curl {{ request.META.HTTP_HOST }}/event/search.json?event_outcome=http://purl.org/net/untl/vocabularies/eventOutcomes/%23failure
+    $ curl "{{ request.META.HTTP_HOST }}/event/search.json?event_outcome=http://purl.org/net/untl/vocabularies/eventOutcomes/%23failure"
     [
         {
             "date": "2013-05-13 14:27:29",
@@ -35,7 +35,7 @@
     ]
 
     # to get the events which failed after a certain date, append a 'start_date' argument
-    $ curl {{ request.META.HTTP_HOST }}/event/search.json?event_outcome=http://purl.org/net/untl/vocabularies/eventOutcomes/%23failure&start_date=05/13/2013
+    $ curl "{{ request.META.HTTP_HOST }}/event/search.json?event_outcome=http://purl.org/net/untl/vocabularies/eventOutcomes/%23failure&start_date=05/13/2013"
 
     [
         {
@@ -49,7 +49,7 @@
     ]
 
     # filter events to a particular bag object by giving a 'linked_object_id'
-    $ curl {{ request.scheme }}://{{ request.META.HTTP_HOST }}/event/search.json?linked_object_id=ark:/67531/coda1295
+    $ curl "{{ request.scheme }}://{{ request.META.HTTP_HOST }}/event/search.json?linked_object_id=ark:/67531/coda1295"
     [
         {
             "date": "2013-05-13 14:27:29",


### PR DESCRIPTION
@ldko  @somexpert 

This PR updates the url examples in about page. The fragment '#failure' and '#success' is getting stripped off by the browser and never sent to server by Http Request and there '#' should be escaped in the url using '%23'.
