### PR TITLE
Add data-upload-max setting

### DIFF
--- a/coda/config/settings.py
+++ b/coda/config/settings.py
@@ -140,3 +140,5 @@ if DEBUG:
     }
     INSTALLED_APPS += ['debug_toolbar']
     MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
+
+DATA_UPLOAD_MAX_NUMBER_FIELDS = get_secret('UPLOAD_MAX')

--- a/docker_secrets.json
+++ b/docker_secrets.json
@@ -12,5 +12,6 @@
   "STATIC_ROOT": "",
   "STATIC_URL": "/static/",
   "DEBUG": true,
-  "TEST_SITE": true
+  "TEST_SITE": true,
+  "UPLOAD_MAX": 1000
 }

--- a/secrets.json.template
+++ b/secrets.json.template
@@ -12,5 +12,6 @@
   "STATIC_ROOT": "",
   "STATIC_URL": "",
   "DEBUG": "",
-  "TEST_SITE": ""
+  "TEST_SITE": "",
+  "UPLOAD_MAX": ""
 }


### PR DESCRIPTION
This is a small change to allow for deleting a larger amount of queue entries (than the default allows) in the admin.