### PR TITLE
Add SECURE_PROXY_SSL_HEADER setting

### DIFF
--- a/coda/config/settings.py
+++ b/coda/config/settings.py
@@ -142,3 +142,4 @@ if DEBUG:
     MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
 
 DATA_UPLOAD_MAX_NUMBER_FIELDS = get_secret('UPLOAD_MAX')
+SECURE_PROXY_SSL_HEADER = get_secret('SECURE_PROXY_SSL_HEADER')

--- a/docker_secrets.json
+++ b/docker_secrets.json
@@ -13,5 +13,6 @@
   "STATIC_URL": "/static/",
   "DEBUG": true,
   "TEST_SITE": true,
-  "UPLOAD_MAX": 1000
+  "UPLOAD_MAX": 1000,
+  "SECURE_PROXY_SSL_HEADER": null
 }

--- a/secrets.json.template
+++ b/secrets.json.template
@@ -13,5 +13,6 @@
   "STATIC_URL": "",
   "DEBUG": "",
   "TEST_SITE": "",
-  "UPLOAD_MAX": ""
+  "UPLOAD_MAX": "",
+  "SECURE_PROXY_SSL_HEADER": null
 }


### PR DESCRIPTION
@somexpert this sets us up to use the SECURE_PROXY_SSL_HEADER setting, so https will work behind a load balancer.